### PR TITLE
Fix an error when building a mapping URI from the ID mapping to GET it

### DIFF
--- a/controllers/mappings_controller.rb
+++ b/controllers/mappings_controller.rb
@@ -83,7 +83,7 @@ class MappingsController < ApplicationController
         mapping_id = RDF::URI.new(params[:mapping])
       else
         mapping_id =
-          "http://data.bioontology.org/rest_backup_mappings/#{mapping_id}"
+          "http://data.bioontology.org/rest_backup_mappings/#{params[:mapping]}"
         mapping_id = RDF::URI.new(mapping_id)
       end
       mapping = LinkedData::Mappings.get_rest_mapping(mapping_id)


### PR DESCRIPTION
You gave the possibility to get a mapping from its URI (e.g.: http://data.bioontology.org/mappings/http%3A%2F%2Fdata.bioontology.org%2Frest_backup_mappings%2F500b5350-c135-0132-3a1a-005056010073 )
Or its UUID (e.g.: http://data.bioontology.org/mappings/500b5350-c135-0132-3a1a-005056010073 )
But there is a little error that make the GET mapping from the UUID not working.
