### PR TITLE
Add Instances pagination, search and order by features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ logs/**
 .tags*
 cache/**
 vendor/bundle/*
+ontologies_api.iml
 
 # YARD artifacts
 .yardoc

--- a/controllers/instances_controller.rb
+++ b/controllers/instances_controller.rb
@@ -8,18 +8,19 @@ class InstancesController < ApplicationController
     cls = get_class(sub)
     error 404 if cls.nil?
 
-    page, size = page_params
-    attributes = get_attributes_to_include(includes_param)
-    order_by = get_order_by_from(@params)
+    attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params
+
 
 
     page_data = LinkedData::Models::Instance.where(filter_classes_by(cls.id))
                                             .in(sub)
                                             .include(attributes)
-    page_data.order_by(order_by) unless (order_by.nil?)
+
+    page_data.filter(filter_by_label) unless filter_by_label.nil?
+    page_data.order_by(order_by) unless order_by.nil?
     page_data = page_data.page(page,size).all
 
-    bring_unmapped_if_needed  includes_param, page_data , sub
+    bring_unmapped_to page_data , sub if bring_unmapped_needed
 
     reply page_data
   end
@@ -30,18 +31,19 @@ class InstancesController < ApplicationController
       ont, sub = get_ontology_and_submission
       check_last_modified_segment(LinkedData::Models::Instance, [ont.acronym])
 
-      page, size = page_params
-      attributes = get_attributes_to_include(includes_param)
-      order_by = get_order_by_from(@params)
+      attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params
 
-      page_data = LinkedData::Models::Instance.where.filter(label_regex_filter)
+
+      page_data = LinkedData::Models::Instance.where
                                               .in(sub)
                                               .include(attributes)
-      page_data.order_by(order_by) unless (order_by.nil?)
+
+      page_data.filter(filter_by_label) unless filter_by_label.nil?
+      page_data.order_by(order_by) unless order_by.nil?
       page_data = page_data.page(page,size).all
 
+      bring_unmapped_to page_data , sub if bring_unmapped_needed
 
-      bring_unmapped_if_needed  includes_param, page_data , sub
       reply page_data
     end
 
@@ -49,12 +51,12 @@ class InstancesController < ApplicationController
       ont, sub = get_ontology_and_submission
       check_last_modified_segment(LinkedData::Models::Instance, [ont.acronym])
 
-      attributes = get_attributes_to_include(includes_param)
+      attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params
 
       page_data = LinkedData::Models::Instance.find(@params["inst"]).include(attributes).in(sub).first
 
+      bring_unmapped_to [page_data] , sub if bring_unmapped_needed
 
-      bring_unmapped_if_needed  includes_param, [page_data] , sub
       reply page_data
     end
   end

--- a/controllers/instances_controller.rb
+++ b/controllers/instances_controller.rb
@@ -2,21 +2,39 @@ class InstancesController < ApplicationController
 
   # Display individuals for a class
   get '/ontologies/:ontology/classes/:cls/instances' do
+
     ont, sub = get_ontology_and_submission
-    check_last_modified_segment(LinkedData::Models::Class, [ont.acronym])
+    check_last_modified_segment(LinkedData::Models::Instance, [ont.acronym])
     cls = get_class(sub)
     error 404 if cls.nil?
-    reply LinkedData::InstanceLoader.get_instances_by_class(sub.id, cls.id)
+    page, size = page_params
+
+    unmapped =  (includes_param && includes_param.include?(:all))
+    page_data = LinkedData::Models::Instance.where(cls.id.nil? ? nil :{types: RDF::URI.new(cls.id.to_s)}).in(sub)
+                                            .include(LinkedData::Models::Instance.attributes).page(page,size).all
+
+    if unmapped && page_data.length > 0
+      LinkedData::Models::Instance.in(sub).models(page_data).include(:unmapped).all
+    end
+    reply page_data
   end
 
   namespace "/ontologies/:ontology/instances" do
-
     # Display individuals for an ontology
     get do
       ont, sub = get_ontology_and_submission
       check_last_modified_segment(LinkedData::Models::Instance, [ont.acronym])
       page, size = page_params
-      reply LinkedData::InstanceLoader.get_instances_by_ontology(sub.id, page, size)
+
+      unmapped = (includes_param && includes_param.include?(:all))
+      page_data = LinkedData::Models::Instance.in(sub)
+                                              .include(LinkedData::Models::Instance.attributes)
+                                              .page(page,size).all
+
+      if unmapped && page_data.length > 0
+        LinkedData::Models::Instance.in(sub).models(page_data).include(:unmapped).all
+      end
+      reply page_data
     end
 
   end

--- a/controllers/instances_controller.rb
+++ b/controllers/instances_controller.rb
@@ -37,6 +37,19 @@ class InstancesController < ApplicationController
       reply page_data
     end
 
+    get '/:inst' do
+      ont, sub = get_ontology_and_submission
+      check_last_modified_segment(LinkedData::Models::Instance, [ont.acronym])
+
+      unmapped = (includes_param && includes_param.include?(:all))
+
+      page_data = LinkedData::Models::Instance.find(@params["inst"]).include(LinkedData::Models::Instance.attributes).in(sub).first
+
+      if unmapped
+        LinkedData::Models::Instance.in(sub).models([page_data]).include(:unmapped).all
+      end
+      reply page_data
+    end
   end
 end
 

--- a/controllers/instances_controller.rb
+++ b/controllers/instances_controller.rb
@@ -10,10 +10,12 @@ class InstancesController < ApplicationController
 
     page, size = page_params
     attributes = get_attributes_to_include(includes_param)
-
+    order_by = get_order_by_from(@params)
     page_data = LinkedData::Models::Instance.where(filter_classes_by(cls.id))
                                             .filter(label_regex_filter).in(sub)
-                                            .include(attributes).page(page,size).all
+                                            .include(attributes)
+                                            .order_by(order_by)
+                                            .page(page,size).all
 
     bring_unmapped_if_needed  includes_param, page_data , sub
 
@@ -28,10 +30,11 @@ class InstancesController < ApplicationController
 
       page, size = page_params
       attributes = get_attributes_to_include(includes_param)
-
+      order_by = get_order_by_from(@params)
       page_data = LinkedData::Models::Instance.where.filter(label_regex_filter)
                                               .in(sub)
                                               .include(attributes)
+                                              .order_by(order_by)
                                               .page(page,size).all
 
       bring_unmapped_if_needed  includes_param, page_data , sub

--- a/controllers/instances_controller.rb
+++ b/controllers/instances_controller.rb
@@ -27,7 +27,11 @@ class InstancesController < ApplicationController
       page, size = page_params
 
       unmapped = (includes_param && includes_param.include?(:all))
-      page_data = LinkedData::Models::Instance.in(sub)
+
+
+      f_label = (Goo::Filter.new(:label).regex(@params["search"])) if @params["search"] != ""
+      page_data = LinkedData::Models::Instance.where.filter(f_label)
+                                              .in(sub)
                                               .include(LinkedData::Models::Instance.attributes)
                                               .page(page,size).all
 

--- a/controllers/instances_controller.rb
+++ b/controllers/instances_controller.rb
@@ -11,11 +11,13 @@ class InstancesController < ApplicationController
     page, size = page_params
     attributes = get_attributes_to_include(includes_param)
     order_by = get_order_by_from(@params)
+
+
     page_data = LinkedData::Models::Instance.where(filter_classes_by(cls.id))
-                                            .filter(label_regex_filter).in(sub)
+                                            .in(sub)
                                             .include(attributes)
-                                            .order_by(order_by)
-                                            .page(page,size).all
+    page_data.order_by(order_by) unless (order_by.nil?)
+    page_data = page_data.page(page,size).all
 
     bring_unmapped_if_needed  includes_param, page_data , sub
 
@@ -31,11 +33,13 @@ class InstancesController < ApplicationController
       page, size = page_params
       attributes = get_attributes_to_include(includes_param)
       order_by = get_order_by_from(@params)
+
       page_data = LinkedData::Models::Instance.where.filter(label_regex_filter)
                                               .in(sub)
                                               .include(attributes)
-                                              .order_by(order_by)
-                                              .page(page,size).all
+      page_data.order_by(order_by) unless (order_by.nil?)
+      page_data = page_data.page(page,size).all
+
 
       bring_unmapped_if_needed  includes_param, page_data , sub
       reply page_data

--- a/helpers/instances_helper.rb
+++ b/helpers/instances_helper.rb
@@ -4,7 +4,7 @@ module Sinatra
   module Helpers
     module InstancesHelper
       def label_regex_filter
-        (Goo::Filter.new(:label).regex(@params["search"])) if @params["search"] != ""
+        (Goo::Filter.new(:label).regex(@params["search"])) if @params["search"] != nil
       end
 
       def filter_classes_by(class_uri)
@@ -12,7 +12,7 @@ module Sinatra
       end
 
       def get_order_by_from(params , default_sort = :label , default_order = :asc)
-        {(params["sortby"] || default_sort).to_sym => params["order"] || default_order}
+        {(params["sortby"] || default_sort).to_sym => params["order"] || default_order} unless params["sortby"].nil? || params["sortby"] == ""
       end
 
       def get_attributes_to_include(includes_param)

--- a/helpers/instances_helper.rb
+++ b/helpers/instances_helper.rb
@@ -3,8 +3,24 @@ require 'sinatra/base'
 module Sinatra
   module Helpers
     module InstancesHelper
+
+      # TODO: generalize this to all routes (maybe in application_helper)
+      def settings_params
+        page, size = page_params
+        attributes = get_attributes_to_include(includes_param)
+        order_by = get_order_by_from(@params)
+        bring_unmapped = bring_unmapped?(includes_param)
+        filter_by_label = label_regex_filter
+
+        [attributes, page, size, filter_by_label, order_by, bring_unmapped]
+      end
+
+      def is_set?(param)
+        !param.nil? && param != ""
+      end
+
       def label_regex_filter
-        (Goo::Filter.new(:label).regex(@params["search"])) if @params["search"] != nil
+        (Goo::Filter.new(:label).regex(@params["search"])) if is_set?(@params["search"])
       end
 
       def filter_classes_by(class_uri)
@@ -12,7 +28,7 @@ module Sinatra
       end
 
       def get_order_by_from(params , default_sort = :label , default_order = :asc)
-        {(params["sortby"] || default_sort).to_sym => params["order"] || default_order} unless params["sortby"].nil? || params["sortby"] == ""
+        {(params["sortby"] || default_sort).to_sym => params["order"] || default_order} if is_set?(@params["sortby"])
       end
 
       def get_attributes_to_include(includes_param)
@@ -29,11 +45,6 @@ module Sinatra
         LinkedData::Models::Instance.in(sub).models(page_data).include(:unmapped).all
       end
 
-      def bring_unmapped_if_needed(includes_param , page_data , sub)
-        if bring_unmapped?(includes_param) && page_data.length > 0
-          bring_unmapped_to page_data , sub
-        end
-      end
     end
   end
 end

--- a/helpers/instances_helper.rb
+++ b/helpers/instances_helper.rb
@@ -1,0 +1,37 @@
+require 'sinatra/base'
+
+module Sinatra
+  module Helpers
+    module InstancesHelper
+      def label_regex_filter
+        (Goo::Filter.new(:label).regex(@params["search"])) if @params["search"] != ""
+      end
+
+      def filter_classes_by(class_uri)
+        class_uri.nil? ? nil :{types: RDF::URI.new(class_uri.to_s)}
+      end
+
+      def get_attributes_to_include(includes_param)
+        ld = LinkedData::Models::Instance.goo_attrs_to_load(includes_param)
+        ld.delete(:properties)
+        ld
+      end
+
+      def bring_unmapped?(includes_param)
+        (includes_param && includes_param.include?(:all))
+      end
+
+      def bring_unmapped_to(page_data, sub)
+        LinkedData::Models::Instance.in(sub).models(page_data).include(:unmapped).all
+      end
+
+      def bring_unmapped_if_needed(includes_param , page_data , sub)
+        if bring_unmapped?(includes_param) && page_data.length > 0
+          bring_unmapped_to page_data , sub
+        end
+      end
+    end
+  end
+end
+
+helpers Sinatra::Helpers::InstancesHelper

--- a/helpers/instances_helper.rb
+++ b/helpers/instances_helper.rb
@@ -11,6 +11,10 @@ module Sinatra
         class_uri.nil? ? nil :{types: RDF::URI.new(class_uri.to_s)}
       end
 
+      def get_order_by_from(params , default_sort = :label , default_order = :asc)
+        {(params["sortby"] || default_sort).to_sym => params["order"] || default_order}
+      end
+
       def get_attributes_to_include(includes_param)
         ld = LinkedData::Models::Instance.goo_attrs_to_load(includes_param)
         ld.delete(:properties)


### PR DESCRIPTION
## To Merge before 
- [ ] https://github.com/ncbo/goo/pull/116
- [ ] https://github.com/ncbo/ontologies_linked_data/pull//129

## What?
See  https://github.com/ncbo/ontologies_linked_data/pull/123
In addition here we have added two features
- The search feature using https://github.com/ncbo/goo/pull/115 
- The order by feature

## How to use
### The pagination feature
Instance pagination is the default response of the following routes :
- instances by a class : '/ontologies/:ontology/classes/:cls/instances'
- instances by an ontology : /ontologies/:ontology/instances

### The search feature
Adding the parameter "search=string" in the instances paths (routes), will filter the instances by the label (rdf:label), see example below
![image](https://user-images.githubusercontent.com/29259906/151388235-861612fe-fbfa-4098-89ab-7d9e4e65edf0.png)

### Order by feature
Order by works by using the parameters "sortby={property}" and "order={ASC|DESC}", see example below
![image](https://user-images.githubusercontent.com/29259906/151389434-3d5e96a3-db6b-4981-b499-b1f38fb712ee.png)



# Anything Else?
About me: IT engineer at LIRMM & MISTEA for Agroportal (France)
contact me at : syphax.bouazzouni@lirmm.fr or in the Ontoportal Alliance Slack