### PR TITLE
Fix get a submission metrics

### DIFF
--- a/controllers/metrics_controller.rb
+++ b/controllers/metrics_controller.rb
@@ -85,7 +85,6 @@ class MetricsController < ApplicationController
   get "/ontologies/:ontology/metrics" do
     check_last_modified_collection(LinkedData::Models::Metric)
     ont, sub = get_ontology_and_submission
-    ont = Ontology.find(params["ontology"]).first
     error 404, "Ontology #{params['ontology']} not found" unless ont
     sub.bring(ontology: [:acronym], metrics: LinkedData::Models::Metric.goo_attrs_to_load(includes_param))
     reply sub.metrics || {}
@@ -106,10 +105,9 @@ class MetricsController < ApplicationController
     # reply {}
   end
 
-  get "/ontologies/:ontology/submissions/:submissionId/metrics" do
+  get "/ontologies/:ontology/submissions/:ontology_submission_id/metrics" do
     check_last_modified_collection(LinkedData::Models::Metric)
     ont, sub = get_ontology_and_submission
-    ont = Ontology.find(params["ontology"]).first
     error 404, "Ontology #{params['ontology']} not found" unless ont
     sub.bring(ontology: [:acronym], metrics: LinkedData::Models::Metric.goo_attrs_to_load(includes_param))
     reply sub.metrics || {}


### PR DESCRIPTION
fix https://github.com/ncbo/ontologies_api/issues/77

The was that the function [get_ontology_and_submission](https://github.com/ontoportal-lirmm/ontologies_api/blob/faa3a99ace7ddffa78ccfe70829033d80e25738e/helpers/application_helper.rb#L379) use the parameter key **ontology_submission_id** not the key  **submissionId** specified in the action path.