### PR TITLE
Fix to ignore no writable attributes in the patch endpoints 

### DIFF
--- a/helpers/application_helper.rb
+++ b/helpers/application_helper.rb
@@ -21,9 +21,10 @@ module Sinatra
 
         # Make sure everything is loaded
         if obj.is_a?(LinkedData::Models::Base)
-          obj.bring_remaining unless !obj.exist?
+          obj.bring_remaining if obj.exist?
+          no_writable_attributes = obj.class.attributes(:all) - obj.class.attributes
+          params = params.reject  {|k,v| no_writable_attributes.include? k.to_sym}
         end
-
         params.each do |attribute, value|
           next if value.nil?
 


### PR DESCRIPTION
## To reproduce the bug 
Do a path request to the /ontologies/{acronym} endpoint, with the body containing no writable attributes (inverse and handlers attributes e.g views)
![image](https://user-images.githubusercontent.com/29259906/169664635-85bcb22c-f32d-4a0e-8cc4-8425706eadbf.png)
