### PR TITLE
Feature: Add the slices CRUD endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'goo', github: 'ncbo/goo', branch: 'master'
 gem 'ncbo_annotator', github: 'ncbo/ncbo_annotator', branch: 'master'
 gem 'ncbo_cron', github: 'ncbo/ncbo_cron', branch: 'master'
 gem 'ncbo_ontology_recommender', github: 'ncbo/ncbo_ontology_recommender', branch: 'master'
-gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'master'
+gem 'ontologies_linked_data', github: 'ontoportal-lirmm/ontologies_linked_data', branch: 'pr/feature/extend-slice-acronym-validator'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'master'
 
 group :masterment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,9 +52,19 @@ GIT
       redis
 
 GIT
-  remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: a7ad210e846a390f203457be2459719214d142fe
+  remote: https://github.com/ncbo/sparql-client.git
+  revision: d418d56a6c9ff5692f925b45739a2a1c66bca851
   branch: master
+  specs:
+    sparql-client (1.0.1)
+      json_pure (>= 1.4)
+      net-http-persistent (= 2.9.4)
+      rdf (>= 1.0)
+
+GIT
+  remote: https://github.com/ontoportal-lirmm/ontologies_linked_data.git
+  revision: da59b8c14157937055e5ff0b0fc4dd9a1e6ba4be
+  branch: pr/feature/extend-slice-acronym-validator
   specs:
     ontologies_linked_data (0.0.1)
       activesupport
@@ -70,16 +80,6 @@ GIT
       rack-test
       rsolr
       rubyzip
-
-GIT
-  remote: https://github.com/ncbo/sparql-client.git
-  revision: d418d56a6c9ff5692f925b45739a2a1c66bca851
-  branch: master
-  specs:
-    sparql-client (1.0.1)
-      json_pure (>= 1.4)
-      net-http-persistent (= 2.9.4)
-      rdf (>= 1.0)
 
 GIT
   remote: https://github.com/palexander/rack-post-body-to-params.git
@@ -105,7 +105,7 @@ GEM
       multi_json (~> 1.0)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
-    airbrussh (1.4.2)
+    airbrussh (1.5.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     backports (3.24.1)
@@ -114,7 +114,7 @@ GEM
     bcrypt_pbkdf (1.1.0)
     bigdecimal (1.4.2)
     builder (3.2.4)
-    capistrano (3.17.3)
+    capistrano (3.18.0)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -143,7 +143,7 @@ GEM
     faraday-net_http (3.0.2)
     faraday-retry (2.2.0)
       faraday (~> 2.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     gapic-common (0.20.0)
       faraday (>= 1.9, < 3.a)
       faraday-retry (>= 1.0, < 3.a)
@@ -246,7 +246,7 @@ GEM
     os (1.1.4)
     parallel (1.23.0)
     parseconfig (1.1.2)
-    parser (3.2.2.3)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
     pony (1.13.1)
@@ -278,16 +278,16 @@ GEM
     rdf (1.0.8)
       addressable (>= 2.2)
     redcarpet (3.6.0)
-    redis (5.0.7)
-      redis-client (>= 0.9.0)
-    redis-client (0.17.0)
+    redis (5.0.8)
+      redis-client (>= 0.17.0)
+    redis-client (0.18.0)
       connection_pool
     redis-rack-cache (2.2.1)
       rack-cache (>= 1.10, < 2)
       redis-store (>= 1.6, < 2)
     redis-store (1.10.0)
       redis (>= 4, < 6)
-    regexp_parser (2.8.1)
+    regexp_parser (2.8.2)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -297,19 +297,18 @@ GEM
     rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
-    rubocop (1.56.3)
-      base64 (~> 0.1.1)
+    rubocop (1.57.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.2.2.4)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
       rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
+    rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby-xxHash (0.4.0.2)
@@ -348,7 +347,7 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     systemu (2.6.5)
-    temple (0.10.2)
+    temple (0.10.3)
     tilt (2.3.0)
     timeout (0.4.0)
     tzinfo (2.0.6)
@@ -356,7 +355,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.5.0)
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -422,4 +421,4 @@ DEPENDENCIES
   unicorn-worker-killer
 
 BUNDLED WITH
-   2.4.17
+   2.4.12

--- a/controllers/slices_controller.rb
+++ b/controllers/slices_controller.rb
@@ -19,6 +19,13 @@ class SlicesController < ApplicationController
     post do
       create_slice
     end
+
+    # Delete a slice
+    delete '/:slice' do
+      LinkedData::Models::Slice.find(params[:slice]).first.delete
+      halt 204
+    end
+
     private
 
     def create_slice

--- a/controllers/slices_controller.rb
+++ b/controllers/slices_controller.rb
@@ -17,17 +17,20 @@ class SlicesController < ApplicationController
     ##
     # Create a new slice
     post do
+      error 403, "Access denied" unless current_user && current_user.admin?
       create_slice
     end
 
     # Delete a slice
     delete '/:slice' do
+      error 403, "Access denied" unless current_user && current_user.admin?
       LinkedData::Models::Slice.find(params[:slice]).first.delete
       halt 204
     end
 
     # Update an existing slice
     patch '/:slice' do
+      error 403, "Access denied" unless current_user && current_user.admin?
       slice = LinkedData::Models::Slice.find(params[:slice]).include(LinkedData::Models::Slice.attributes(:all)).first
       populate_from_params(slice, params)
       if slice.valid?

--- a/controllers/slices_controller.rb
+++ b/controllers/slices_controller.rb
@@ -26,6 +26,18 @@ class SlicesController < ApplicationController
       halt 204
     end
 
+    # Update an existing slice
+    patch '/:slice' do
+      slice = LinkedData::Models::Slice.find(params[:slice]).include(LinkedData::Models::Slice.attributes(:all)).first
+      populate_from_params(slice, params)
+      if slice.valid?
+        slice.save
+      else
+        error 422, slice.errors
+      end
+      halt 204
+    end
+    
     private
 
     def create_slice

--- a/controllers/slices_controller.rb
+++ b/controllers/slices_controller.rb
@@ -6,5 +6,13 @@ class SlicesController < ApplicationController
       includes = LinkedData::Models::Slice.goo_attrs_to_load(includes_param)
       reply LinkedData::Models::Slice.where.include(includes).all
     end
+
+    get '/:slice_id' do
+      slice = LinkedData::Models::Slice.where(acronym: params["slice_id"]).first
+      error 404, "Slice #{params['slice_id']} not found" if slice.nil?
+      check_last_modified(slice)
+      slice.bring(*LinkedData::Models::Slice.goo_attrs_to_load(includes_param))
+      reply slice
+    end
   end
 end

--- a/controllers/slices_controller.rb
+++ b/controllers/slices_controller.rb
@@ -14,5 +14,35 @@ class SlicesController < ApplicationController
       slice.bring(*LinkedData::Models::Slice.goo_attrs_to_load(includes_param))
       reply slice
     end
+    ##
+    # Create a new slice
+    post do
+      create_slice
+    end
+    private
+
+    def create_slice
+      params ||= @params
+      ontologies = []
+
+      params["ontologies"].each do |ont|
+        ontologies.push(LinkedData::Models::Ontology.find(ont).first)
+      end
+
+      slice = LinkedData::Models::Slice.new({
+                                              acronym: params["acronym"],
+                                              name: params["name"],
+                                              description: params["description"],
+                                              ontologies: ontologies
+                                            })
+
+      if slice.valid?
+        slice.save
+      else
+        error 400, slice.errors
+      end
+      reply 201, slice
+    end
+
   end
 end

--- a/test/controllers/test_slices_controller.rb
+++ b/test/controllers/test_slices_controller.rb
@@ -3,28 +3,94 @@ require_relative '../test_case'
 class TestSlicesController < TestCase
 
   def self.before_suite
-    onts = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(ont_count: 1, submission_count: 0)[2]
+    ont_count, ont_acronyms, @@onts = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(ont_count: 1, submission_count: 0)
 
     @@slice_acronyms = ["tst-a", "tst-b"].sort
-    _create_slice(@@slice_acronyms[0], "Test Slice A", onts)
-    _create_slice(@@slice_acronyms[1], "Test Slice B", onts)
+    _create_slice(@@slice_acronyms[0], "Test Slice A", @@onts)
+    _create_slice(@@slice_acronyms[1], "Test Slice B", @@onts)
+
+    @@user = User.new({
+                        username: "test-slice",
+                        email: "test-slice@example.org",
+                        password: "12345"
+                      }).save
+    @@new_slice_data = { acronym: 'tst-c', name: "Test Slice C", ontologies: ont_acronyms}
+    @@old_security_setting = LinkedData.settings.enable_security
+  end
+
+  def self.after_suite
+    LinkedData::Models::Slice.all.each(&:delete)
+  end
+
+  def setup
+    reset_security
+    rest_to_not_admin(@@user)
+    LinkedData::Models::Slice.find(@@new_slice_data[:acronym]).first&.delete
   end
 
   def test_all_slices
     get "/slices"
     assert last_response.ok?
     slices = MultiJson.load(last_response.body)
-    assert_equal @@slice_acronyms, slices.map {|s| s["acronym"]}.sort
+    assert_equal @@slice_acronyms, slices.map { |s| s["acronym"] }.sort
+  end
+
+  def test_create_slices
+    enable_security
+
+    post "/slices?apikey=#{@@user.apikey}", MultiJson.dump(@@new_slice_data), "CONTENT_TYPE" => "application/json"
+    assert_equal 403, last_response.status
+
+    make_admin(@@user)
+
+    post "/slices?apikey=#{@@user.apikey}", MultiJson.dump(@@new_slice_data), "CONTENT_TYPE" => "application/json"
+
+    assert 201, last_response.status
+  end
+
+  def test_delete_slices
+    enable_security
+    LinkedData.settings.enable_security = @@old_security_setting
+    self.class._create_slice(@@new_slice_data[:acronym],  @@new_slice_data[:name], @@onts)
+
+
+    delete "/slices/#{@@new_slice_data[:acronym]}?apikey=#{@@user.apikey}"
+    assert_equal 403, last_response.status
+
+    make_admin(@@user)
+
+    delete "/slices/#{@@new_slice_data[:acronym]}?apikey=#{@@user.apikey}"
+    assert 201, last_response.status
   end
 
   private
 
   def self._create_slice(acronym, name, ontologies)
     slice = LinkedData::Models::Slice.new({
-      acronym: acronym,
-      name: "Test #{name}",
-      ontologies: ontologies
-    })
+                                            acronym: acronym,
+                                            name: "Test #{name}",
+                                            ontologies: ontologies
+                                          })
     slice.save
+  end
+
+  def enable_security
+    LinkedData.settings.enable_security = true
+  end
+
+  def reset_security
+    LinkedData.settings.enable_security = @@old_security_setting
+  end
+
+  def make_admin(user)
+    user.bring_remaining
+    user.role = [LinkedData::Models::Users::Role.find(LinkedData::Models::Users::Role::ADMIN).first]
+    user.save
+  end
+
+  def rest_to_not_admin(user)
+    user.bring_remaining
+    user.role = [LinkedData::Models::Users::Role.find(LinkedData::Models::Users::Role::DEFAULT).first]
+    user.save
   end
 end


### PR DESCRIPTION
Forked from #19 

This PR adds the following endpoints : 
- Create slice `POST  https://data.bioontology.org/sclices`
- Get slice details `GET https://data.bioontology.org/sclices/:slice_id`
- Update slide info `POST https://data.bioontology.org/sclices/:slice_id `
- Delete a slice `DELETE https://data.bioontology.org/sclices/:slice_id` 

Our long-term vision behind slices can be found [here](https://github.com/agroportal/project-management/issues/35#issuecomment-1209693008); In brief gives the possibility the users to create their slices, with their ontologies, colors, and logo, .... Making Ontoportal a sort a Portal provider for people that don't want or don't have the resources to deploy there own instances (and with portal federation, everything will be also connected).

The biggest blocker here, about the slice features is that we can't can't dynamically create a DSN configuration for each of the slices created by a user. 
