### PR TITLE
confirm to minitest style guide

### DIFF
--- a/test/controllers/test_search_controller.rb
+++ b/test/controllers/test_search_controller.rb
@@ -256,9 +256,9 @@ class TestSearchController < TestCase
       assert_equal ncit_acronym, LinkedData::Utils::Triples.last_iri_fragment(docs[2]["links"]["ontology"])
       assert_equal 'realization', docs[1]["prefLabel"]
       assert_equal 'realization', docs[2]["prefLabel"]
-      assert docs[3]["prefLabel"].upcase.include?('OGMS ')
-      assert docs[4]["prefLabel"].upcase.include?('OGMS ')
-      assert docs[5]["prefLabel"].upcase.include?('OGMS ')
+      assert_includes docs[3]["prefLabel"].upcase, 'OGMS '
+      assert_includes docs[4]["prefLabel"].upcase, 'OGMS '
+      assert_includes docs[5]["prefLabel"].upcase, 'OGMS '
 
       get "/search?q=CNO:0000002"
       assert last_response.ok?
@@ -267,13 +267,13 @@ class TestSearchController < TestCase
       assert_equal 7, docs.size
       assert_equal cno_acronym, LinkedData::Utils::Triples.last_iri_fragment(docs[0]["links"]["ontology"])
       acr_1 = LinkedData::Utils::Triples.last_iri_fragment(docs[1]["links"]["ontology"])
-      assert acr_1 === ncit_acronym || acr_1 === ogms_acronym
+      assert_includes [ncit_acronym, ogms_acronym], acr_1
       acr_2= LinkedData::Utils::Triples.last_iri_fragment(docs[2]["links"]["ontology"])
-      assert acr_2 === ncit_acronym || acr_2 === ogms_acronym
-      assert docs[3]["prefLabel"].upcase.include?('CNO ')
-      assert docs[4]["prefLabel"].upcase.include?('CNO ')
-      assert docs[5]["prefLabel"].upcase.include?('CNO ')
-      assert docs[6]["prefLabel"].upcase.include?('CNO ')
+      assert_includes [ncit_acronym, ogms_acronym], acr_2
+      assert_includes docs[3]["prefLabel"].upcase, 'CNO'
+      assert_includes docs[4]["prefLabel"].upcase, 'CNO'
+      assert_includes docs[5]["prefLabel"].upcase, 'CNO'
+      assert_includes docs[6]["prefLabel"].upcase, 'CNO'
 
       # mdorf, 3/2/2024, when the : is followed by a LETTER, as in NCIT:C20480,
       # then Solr does not split the query on the tokens,
@@ -304,17 +304,17 @@ class TestSearchController < TestCase
       ont = LinkedData::Models::Ontology.find(ncit_acronym).first
       ont.delete if ont
       ont = LinkedData::Models::Ontology.find(ncit_acronym).first
-      assert ont.nil?
+      assert_nil ont
 
       ont = LinkedData::Models::Ontology.find(ogms_acronym).first
       ont.delete if ont
       ont = LinkedData::Models::Ontology.find(ogms_acronym).first
-      assert ont.nil?
+      assert_nil ont
 
       ont = LinkedData::Models::Ontology.find(cno_acronym).first
       ont.delete if ont
       ont = LinkedData::Models::Ontology.find(cno_acronym).first
-      assert ont.nil?
+      assert_nil ont
     end
   end
 


### PR DESCRIPTION
changes allows to see more detailed output when unit test fail as in #146