### PR TITLE
Feature: make the api use submission naturalLanguage  to choose the default language to display

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'ncbo_annotator', git: 'https://github.com/ncbo/ncbo_annotator.git', branch:
 gem 'ncbo_cron', git: 'https://github.com/ncbo/ncbo_cron.git', branch: 'master'
 gem 'ncbo_ontology_recommender', git: 'https://github.com/ncbo/ncbo_ontology_recommender.git', branch: 'master'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'master'
-gem 'goo', github: 'ontoportal-lirmm/goo', branch: 'pr/sync-agroportal-bioportal'
+gem 'goo', github: 'ncbo/goo', branch: 'develop'
 gem 'ontologies_linked_data', github: 'ontoportal-lirmm/ontologies_linked_data', branch: 'pr/sync-agroportal-ncbo'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,20 @@
 GIT
+  remote: https://github.com/ncbo/goo.git
+  revision: 70007faf43d0d96292809f89f15a27a757ccaa25
+  branch: develop
+  specs:
+    goo (0.0.2)
+      addressable (~> 2.8)
+      pry
+      rdf (= 1.0.8)
+      redis
+      request_store
+      rest-client
+      rsolr
+      sparql-client
+      uuid
+
+GIT
   remote: https://github.com/ncbo/ncbo_annotator.git
   revision: 63c986880aa88c9384043e6611a682434a14aba7
   branch: master
@@ -11,11 +27,13 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_cron.git
-  revision: f239b34230131cd7cfb9eec5b34068ba990b698b
+  revision: 67810ddd2e14876d789c63c427b08af6919f661e
   branch: master
   specs:
     ncbo_cron (0.0.1)
       dante
+      faraday (~> 2)
+      faraday-follow_redirects (~> 0)
       goo
       google-analytics-data
       mlanett-redis-lock
@@ -47,24 +65,8 @@ GIT
       rdf (>= 1.0)
 
 GIT
-  remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: f2751fe9324e48a0a5c2a8b15580ab879fc53a2b
-  branch: pr/sync-agroportal-bioportal
-  specs:
-    goo (0.0.2)
-      addressable (~> 2.8)
-      pry
-      rdf (= 1.0.8)
-      redis
-      request_store
-      rest-client
-      rsolr
-      sparql-client
-      uuid
-
-GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_linked_data.git
-  revision: fc48343ad7a3f1867821c173be900cf16506b4b7
+  revision: 7c5184fc7d3b25b5c9dd54c25f5ea2b1c4951318
   branch: pr/sync-agroportal-ncbo
   specs:
     ontologies_linked_data (0.0.1)
@@ -143,6 +145,8 @@ GEM
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     faraday-retry (2.2.1)
       faraday (~> 2.0)
@@ -223,7 +227,7 @@ GEM
     method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0305)
+    mime-types-data (3.2024.0507)
     mini_mime (1.1.5)
     minitest (4.7.5)
     minitest-stub_any_instance (1.0.3)
@@ -232,7 +236,7 @@ GEM
     multi_json (1.15.0)
     mutex_m (0.2.0)
     net-http-persistent (2.9.4)
-    net-imap (0.4.10)
+    net-imap (0.4.11)
       date
       net-protocol
     net-pop (0.1.2)
@@ -295,7 +299,7 @@ GEM
       redis-store (>= 1.6, < 2)
     redis-store (1.10.0)
       redis (>= 4, < 6)
-    regexp_parser (2.9.0)
+    regexp_parser (2.9.2)
     request_store (1.7.0)
       rack (>= 1.4)
     rest-client (2.1.0)
@@ -303,11 +307,12 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
-    rubocop (1.63.4)
+    rubocop (1.63.5)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -359,6 +364,7 @@ GEM
       net-scp (>= 1.1.2)
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
+    strscan (3.1.0)
     systemu (2.6.5)
     temple (0.10.3)
     tilt (2.3.0)

--- a/helpers/application_helper.rb
+++ b/helpers/application_helper.rb
@@ -409,6 +409,9 @@ module Sinatra
             error 404, "Ontology #{@params["acronym"]} does not have any submissions"
           end
         end
+
+        save_submission_language(submission)
+
         return ont, submission
       end
 
@@ -436,6 +439,22 @@ module Sinatra
         return if object.nil?
         return if Time.now > object[:timeout]
         return object[:object]
+      end
+
+
+      def save_submission_language(submission, language_property = :naturalLanguage)
+        request_lang = RequestStore.store[:requested_lang]
+
+        return if submission.nil? || !request_lang.blank?
+
+        submission.bring(language_property) if submission.bring?(language_property)
+        collection_natural_language = submission.send(language_property) rescue nil
+        return [] if collection_natural_language.blank?
+
+        collection_natural_language = collection_natural_language.values.flatten if collection_natural_language.is_a?(Hash)
+        submissions_language = collection_natural_language.map { |natural_language| natural_language.to_s.split('/').last[0..1] }.compact.first
+
+        RequestStore.store[:requested_lang] =  submissions_language if submissions_language
       end
 
     end

--- a/test/data/ontology_files/BRO_v3.2.owl
+++ b/test/data/ontology_files/BRO_v3.2.owl
@@ -645,7 +645,7 @@
     <owl:Class rdf:about="&activity;Biospecimen_Management">
         <rdfs:subClassOf rdf:resource="&activity;Activity"/>
         <desc:definition rdf:datatype="&xsd;string">Activity related to the creation, use, or maintenance of a biorepository (http://en.wikipedia.org/wiki/Biorepository)</desc:definition>
-        <core:prefLabel rdf:datatype="&xsd;string">Biospecimen Management</core:prefLabel>
+        <core:prefLabel xml:lang="fr">Biospecimen Management</core:prefLabel>
     </owl:Class>
     
 


### PR DESCRIPTION
This PR is a follow-up of https://github.com/ncbo/ontologies_api/pull/148, and makes the API use the following order of priority when displaying values: 
1. Request language if request parameters `lang` or `language` are set.
2. Submission property natural Language first value if filled. 
3. Portal main language, by default set to English 

This is useful when a resource defines all its values in another language than the portal default (English), e.g [MDRGER](https://stagedata.bioontology.org/ontologies/MDRGER/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FMDRGER%2F10018065), has only german values so in the UI as by default we try to display the default portal language which is English, but they do not exist in this case, we display the generated ones at the parsing time (the last part of the URIs).

![image](https://github.com/ncbo/ontologies_api/assets/29259906/f20bc436-2bbc-4ef2-aa2b-354840407713)


With this PR you can specify its natural language to be German, and they will display in the UI and API by default the German values, instead of the portal default language (English)
