### PR TITLE
Feature: Enforce system-controlled attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'goo', github: 'ncbo/goo', branch: 'develop'
 gem 'ncbo_annotator', github: 'ncbo/ncbo_annotator', branch: 'develop'
 gem 'ncbo_cron', github: 'ncbo/ncbo_cron', branch: 'develop'
 gem 'ncbo_ontology_recommender', github: 'ncbo/ncbo_ontology_recommender', branch: 'develop'
-gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'develop'
+gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'feature/system-controlled-attributes'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'develop'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_annotator.git
-  revision: 2abcd54c148d0983570d681506002d9d3782d2eb
+  revision: 6671099a39fffa8b98f21db7593cef35dd296b65
   branch: develop
   specs:
     ncbo_annotator (0.0.1)
@@ -27,7 +27,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_cron.git
-  revision: 9d1b6ba54019cac2eeeb5c173e452b4eebbeaa3a
+  revision: 8b805b30c0278e07f2f2e27cb070d39e4c00e1b1
   branch: develop
   specs:
     ncbo_cron (0.0.1)
@@ -45,7 +45,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_ontology_recommender.git
-  revision: f92a42f660635522eb8709e618ff2e641aef0d17
+  revision: c508796d80764bf748b51e9f1c33e57ea9f14a1d
   branch: develop
   specs:
     ncbo_ontology_recommender (0.0.1)
@@ -56,8 +56,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: eb6d356faf98cdd9d053cd35919d5013d4884688
-  branch: develop
+  revision: 4e8fc52abe600e362a7d7bbeca257cbe9bf5d80b
+  branch: feature/system-controlled-attributes
   specs:
     ontologies_linked_data (0.0.1)
       activesupport
@@ -152,7 +152,7 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    faraday-retry (2.2.1)
+    faraday-retry (2.3.1)
       faraday (~> 2.0)
     ffi (1.17.1)
     ffi (1.17.1-aarch64-linux-gnu)
@@ -229,7 +229,7 @@ GEM
     language_server-protocol (3.17.0.4)
     libxml-ruby (5.0.3)
     lint_roller (1.1.0)
-    logger (1.6.6)
+    logger (1.7.0)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
     mail (2.8.1)
@@ -238,10 +238,10 @@ GEM
       net-pop
       net-smtp
     method_source (1.1.0)
-    mime-types (3.6.1)
+    mime-types (3.6.2)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0318)
+    mime-types-data (3.2025.0402)
     mini_mime (1.1.5)
     minitest (5.25.5)
     minitest-hooks (1.5.2)
@@ -271,7 +271,7 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     netrc (0.11.0)
-    newrelic_rpm (9.17.0)
+    newrelic_rpm (9.18.0)
     oj (3.16.10)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
@@ -281,11 +281,12 @@ GEM
     ostruct (0.6.1)
     parallel (1.26.3)
     parseconfig (1.1.2)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     pony (1.13.1)
       mail (>= 2.0)
+    prism (1.4.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -334,7 +335,7 @@ GEM
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
-    rubocop (1.74.0)
+    rubocop (1.75.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -342,11 +343,12 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.41.0)
+    rubocop-ast (1.44.0)
       parser (>= 3.3.7.2)
+      prism (~> 1.4)
     ruby-progressbar (1.13.0)
     ruby-xxHash (0.4.0.2)
     rubyzip (2.4.1)

--- a/controllers/ontology_submissions_controller.rb
+++ b/controllers/ontology_submissions_controller.rb
@@ -8,6 +8,7 @@ class OntologySubmissionsController < ApplicationController
   ##
   # Create a new submission for an existing ontology
   post "/submissions" do
+    reject_restricted_params!(params, LinkedData::Models::OntologySubmission)
     ont = Ontology.find(uri_as_needed(params["ontology"])).include(Ontology.goo_attrs_to_load).first
     error 422, "You must provide a valid `acronym` to create a new submission" if ont.nil?
     reply 201, create_submission(ont)
@@ -34,6 +35,7 @@ class OntologySubmissionsController < ApplicationController
 
     # Create a new submission for an existing ontology
     post do
+      reject_restricted_params!(params, LinkedData::Models::OntologySubmission) if request.post? || request.patch?
       ont = Ontology.find(params["acronym"]).include(Ontology.attributes).first
       error 422, "You must provide a valid `acronym` to create a new submission" if ont.nil?
       reply 201, create_submission(ont)
@@ -56,6 +58,7 @@ class OntologySubmissionsController < ApplicationController
     # Update an existing submission of an ontology
     REQUIRES_REPROCESS = ["prefLabelProperty", "definitionProperty", "synonymProperty", "authorProperty", "classType", "hierarchyProperty", "obsoleteProperty", "obsoleteParent"]
     patch '/:ontology_submission_id' do
+      reject_restricted_params!(params, LinkedData::Models::OntologySubmission) if request.post? || request.patch?
       ont = Ontology.find(params["acronym"]).first
       error 422, "You must provide an existing `acronym` to patch" if ont.nil?
 

--- a/controllers/users_controller.rb
+++ b/controllers/users_controller.rb
@@ -1,5 +1,11 @@
 class UsersController < ApplicationController
   namespace "/users" do
+    # Reject any incoming params that attempt to set restricted (system-controlled) attributes.
+    # This ensures clients can't override internal fields like :resetTokenExpireTime
+    before do
+      reject_restricted_params!(params, LinkedData::Models::User) if request.post? || request.patch?
+    end
+
     post "/authenticate" do
       user_id       = params["user"]
       user_password = params["password"]

--- a/helpers/request_params_helper.rb
+++ b/helpers/request_params_helper.rb
@@ -41,6 +41,18 @@ module Sinatra
         (includes_param && includes_param.include?(:all))
       end
 
+      def reject_restricted_params!(params, model_class)
+        return unless model_class.respond_to?(:hypermedia_settings)
+
+        restricted = model_class.hypermedia_settings[:system_controlled]
+        return if restricted.nil? || restricted.empty?
+
+        forbidden = params.keys.map(&:to_sym) & restricted
+        return if forbidden.empty?
+
+        error 400, "Invalid request: You cannot set restricted attributes: #{forbidden.join(', ')}"
+      end
+
       private
       def sort_order_item(param, order)
         [param.to_sym, order.to_sym]


### PR DESCRIPTION
This PR adds middleware-level protection to prevent external clients from setting or modifying system-controlled model attributes (e.g., internal fields like `uploadFilePath`, `resetTokenExpireTime`, etc.).

- A new helper `reject_restricted_params!` checks incoming POST/PATCH requests and rejects any attempts to modify restricted fields defined in each model’s system_controlled DSL.
- This logic is added as a before filter in relevant controllers (e.g., UsersController, OntologySubmissionsController).
- For now, this is hardcoded per controller with model-specific class references (e.g., LinkedData::Models::User). Further abstraction may be possible but is deferred for clarity and simplicity.
- Returns 400 Bad Request with helpful error messages when violations are detected.

This is not a full audit—only two models have been done so far as examples. Once DSL and models are reviewed and annotated with `system_controlled` fields in `ontologies_linked_data`, additional coverage can be added.


