### PR TITLE
Feature: Update API search collection test for renamed Solr collections (ALT)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,12 +47,12 @@ gem 'rack-contrib'
 gem 'pandoc-ruby'
 
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', github: 'ncbo/goo', branch: 'development'
+gem 'goo', github: 'ncbo/goo', branch: 'feature/solrcloud-alias-indexing-claude'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'development'
 gem 'ncbo_annotator', github: 'ncbo/ncbo_annotator', branch: 'develop'
-gem 'ncbo_cron', github: 'ncbo/ncbo_cron', branch: 'develop'
+gem 'ncbo_cron', github: 'ncbo/ncbo_cron', branch: 'feature/solrcloud-alias-indexing-claude'
 gem 'ncbo_ontology_recommender', github: 'ncbo/ncbo_ontology_recommender', branch: 'develop'
-gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'develop'
+gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'feature/solrcloud-alias-indexing-claude'
 
 group :development do
   gem 'shotgun', github: 'syphax-bouazzouni/shotgun', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 GIT
   remote: https://github.com/ncbo/goo.git
   revision: fa850f46c94e09b6368ed47728b9cce05b7e9d54
-  branch: development
+  branch: feature/solrcloud-alias-indexing-claude
   specs:
     goo (0.0.2)
       addressable (~> 2.8)
@@ -37,8 +37,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_cron.git
-  revision: 102e0f8f10dcbfbc50301764d84259e5aca2c7b2
-  branch: develop
+  revision: 574d893a48ad2fa0f534ae6f0f79bd6c67a28146
+  branch: feature/solrcloud-alias-indexing-claude
   specs:
     ncbo_cron (0.0.1)
       dante
@@ -66,8 +66,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: a4bbd57fcaa78fa66a11b494384b1791b6e9a6d8
-  branch: develop
+  revision: 974142153de9cd4b1cf66f76366c5f0de7c16980
+  branch: feature/solrcloud-alias-indexing-claude
   specs:
     ontologies_linked_data (0.0.1)
       activesupport

--- a/test/controllers/test_search_models_controller.rb
+++ b/test/controllers/test_search_models_controller.rb
@@ -18,7 +18,7 @@ class TestSearchModelsController < TestCase
     get '/admin/search/collections'
     assert last_response.ok?
     res = MultiJson.load(last_response.body)
-    required = %w[ontology_data ontology_metadata prop_search_core1 term_search_core1]
+    required = %w[ontology_data ontology_metadata prop_search_bootstrap term_search_bootstrap]
     allowed_extra = %w[term_search test_solr]
     collections = res["collections"]
     assert_empty required - collections


### PR DESCRIPTION
## Summary

Updates Gemfile dependencies to point to the SolrCloud alias feature branches and fixes the search collections test to expect the new bootstrap collection names.

## Prerequisites

This PR depends on changes introduced in:

- https://github.com/ncbo/goo/pull/180
- https://github.com/ncbo/ontologies_linked_data/pull/280
- https://github.com/ncbo/ncbo_cron/pull/126

### Changes

- **`Gemfile`**: Points `goo`, `ontologies_linked_data`, and `ncbo_cron` to their respective `feature/solrcloud-alias-indexing-claude` branches
- **`test/controllers/test_search_models_controller.rb`**: Updates the expected collection names from `term_search_core1`/`prop_search_core1` to `term_search_bootstrap`/`prop_search_bootstrap`

## Test plan

- [ ] `bundle exec ruby -Itest test/controllers/test_search_models_controller.rb` passes with the new collection names
- [ ] Full test suite passes: `bundle exec rake test`