### PR TITLE
Enforce slice-based access control on individual ontology endpoints

### DIFF
--- a/controllers/application_controller.rb
+++ b/controllers/application_controller.rb
@@ -5,8 +5,13 @@ class ApplicationController
   extend Sinatra::Delegator
 
   # Run before route
-  before {
-  }
+  before %r{/ontologies/([^/]+).*} do |acronym|
+    if LinkedData.settings.enable_slices && request.get?
+      unless ontology_in_slice?(acronym)
+        error 404, "Ontology not found"
+      end
+    end
+  end
 
   # Run after route
   after {

--- a/helpers/slices_helper.rb
+++ b/helpers/slices_helper.rb
@@ -25,7 +25,7 @@ module Sinatra
         slice = current_slice
         return true unless slice
 
-        ont_id = (LinkedData::Models::Ontology.id_prefix + acronym).to_s
+        ont_id = LinkedData::Models::Ontology.id_from_unique_attribute(:acronym, acronym).to_s
         slice.ontology_id_set.include?(ont_id)
       end
 

--- a/helpers/slices_helper.rb
+++ b/helpers/slices_helper.rb
@@ -18,12 +18,28 @@ module Sinatra
         obj.select { |o| slice.ontology_id_set.include?(o.id.to_s) }
       end
 
+      def ontology_in_slice?(acronym)
+        return true unless LinkedData.settings.enable_slices
+        return true unless slice_request?
+
+        slice = current_slice
+        return true unless slice
+
+        ont_id = (LinkedData::Models::Ontology.id_prefix + acronym).to_s
+        slice.ontology_id_set.include?(ont_id)
+      end
+
       def slice_request?
-        env['ncbo.slice'] && !LinkedData::Models::Slice.find(env['ncbo.slice']).first.nil?
+        return env['ncbo.slice.is_request'] if env.key?('ncbo.slice.is_request')
+
+        env['ncbo.slice.is_request'] = !!(env['ncbo.slice'] && current_slice)
       end
 
       def current_slice
-        LinkedData::Models::Slice.find(env['ncbo.slice']).include(LinkedData::Models::Slice.attributes).first
+        return env['ncbo.slice.object'] if env.key?('ncbo.slice.object')
+
+        env['ncbo.slice.object'] = LinkedData::Models::Slice.find(env['ncbo.slice'])
+                                     .include(LinkedData::Models::Slice.attributes).first
       end
 
       def current_slice_acronyms

--- a/test/helpers/test_slices_helper.rb
+++ b/test/helpers/test_slices_helper.rb
@@ -29,6 +29,9 @@ class TestSlicesHelper < TestCaseHelpers
 
     @@group.bring(:ontologies)
 
+    # TODO: This test uses @@group_acronym as the slice identifier throughout. Consider
+    # introducing a @@slice_acronym variable to better reflect that slices and groups are
+    # distinct concepts — not all groups become slices (only those with ontologies).
     LinkedData::Models::Slice.synchronize_groups_to_slices
   end
 
@@ -74,6 +77,41 @@ class TestSlicesHelper < TestCaseHelpers
     results = MultiJson.load(last_response.body)["collection"]
     group_ids = @@group.ontologies.map {|o| o.id.to_s}
     assert results.all? {|r| group_ids.include?(r["links"]["ontology"])}
+  end
+
+  def test_single_ontology_in_slice_returns_200
+    ont = @@onts[0]
+    ont.bring(:acronym)
+    get "http://#{@@group_acronym}.dev/ontologies/#{ont.acronym}"
+    assert last_response.ok?, "Expected 200 for ontology in slice, got #{last_response.status}"
+  end
+
+  def test_single_ontology_not_in_slice_returns_404
+    ont = @@onts[3]
+    ont.bring(:acronym)
+    get "http://#{@@group_acronym}.dev/ontologies/#{ont.acronym}"
+    assert_equal 404, last_response.status
+  end
+
+  def test_single_ontology_not_in_slice_via_header_returns_404
+    ont = @@onts[3]
+    ont.bring(:acronym)
+    get "/ontologies/#{ont.acronym}", {}, "HTTP_NCBO_SLICE" => @@group_acronym
+    assert_equal 404, last_response.status
+  end
+
+  def test_single_ontology_without_slice_returns_200
+    ont = @@onts[3]
+    ont.bring(:acronym)
+    get "/ontologies/#{ont.acronym}"
+    assert last_response.ok?, "Expected 200 without slice context, got #{last_response.status}"
+  end
+
+  def test_ontology_sub_route_not_in_slice_returns_404
+    ont = @@onts[3]
+    ont.bring(:acronym)
+    get "http://#{@@group_acronym}.dev/ontologies/#{ont.acronym}/submissions"
+    assert_equal 404, last_response.status
   end
 
   def test_mappings_slices


### PR DESCRIPTION
## Summary

Resolves https://github.com/ncbo/bioportal-project/issues/370

When accessing BioPortal via a slice subdomain (e.g., `umls.bioportal.bioontology.org`), `GET /ontologies` correctly filters to only show slice ontologies. However, individual ontology access (`GET /ontologies/EFO`) and all sub-routes (`/submissions`, `/classes`, etc.) bypass slice filtering entirely — returning 200 for ontologies not in the slice.

**Root cause:** `filter_for_slice()` only filters collections (`obj.is_a?(Enumerable)`). Single objects pass through unfiltered.

### Changes

- **`controllers/application_controller.rb`** — Add a Sinatra `before` filter on `/ontologies/:acronym` routes (and all sub-routes) that checks slice membership and returns 404 for ontologies not in the current slice. Only applies to GET requests when `enable_slices` is true.
- **`helpers/slices_helper.rb`** — Add `ontology_in_slice?(acronym)` guard method that constructs the ontology ID from the acronym (no extra triplestore query). Memoize `current_slice` and `slice_request?` per request to avoid duplicate triplestore queries.
- **`test/helpers/test_slices_helper.rb`** — Add 5 test cases: in-slice returns 200, not-in-slice returns 404 (via subdomain and header), no-slice context returns 200, and sub-routes also return 404.

## Test plan

- [x] `bundle exec rake test:docker:fs TEST=test/helpers/test_slices_helper.rb` — 10 tests, 0 failures
- [ ] Verify on staging with a slice subdomain: `GET /ontologies/:acronym` for an ontology NOT in the slice returns 404
- [ ] Verify `GET /ontologies` list filtering still works as before
- [ ] Verify non-slice access (e.g., `data.bioontology.org`) is unaffected