### PR TITLE
Fix: always paginate GET /users; /search 500 on empty acronym filter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_cron.git
-  revision: d92fd430629eb070ef5a2e01b4f613b3b1f05a5a
+  revision: b0236e0f2ef9a2083a9c9a2c9df6da817d03aa84
   branch: develop
   specs:
     ncbo_cron (0.0.1)
@@ -66,7 +66,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 24c5a6d0a9de0ec6510d2615cc2e98c93c370a4e
+  revision: cdbf8f6990f10181f3efa11afada051a8283978e
   branch: develop
   specs:
     ontologies_linked_data (0.0.1)
@@ -173,7 +173,7 @@ GEM
     date (3.5.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
-    down (5.6.0)
+    down (5.5.0)
       addressable (~> 2.8)
       base64 (~> 0.3)
     drb (2.2.3)
@@ -192,9 +192,15 @@ GEM
       faraday (~> 2.0)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
     ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -227,6 +233,7 @@ GEM
     google-protobuf (3.25.3)
     google-protobuf (3.25.3-aarch64-linux)
     google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86-linux)
     google-protobuf (3.25.3-x86_64-darwin)
     google-protobuf (3.25.3-x86_64-linux)
     googleapis-common-protos (1.8.0)
@@ -250,6 +257,9 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     grpc (1.70.1-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.70.1-x86-linux)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     grpc (1.70.1-x86_64-darwin)
@@ -327,7 +337,7 @@ GEM
       uri (>= 0.11.1)
     net-http-persistent (4.0.8)
       connection_pool (>= 2.2.4, < 4)
-    net-imap (0.6.4)
+    net-imap (0.6.3)
       date
       net-protocol
     net-pop (0.1.2)
@@ -512,11 +522,20 @@ GEM
     webrick (1.9.2)
 
 PLATFORMS
+  aarch64-linux
   aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
   arm64-darwin
   ruby
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
   x86_64-darwin
+  x86_64-linux
   x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   activesupport
@@ -609,7 +628,7 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   domain_name (0.6.20240107) sha256=5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933
-  down (5.6.0) sha256=48ec6ddb078cbf3b425d02596bb388303316f976143c6e94a7b3169d6712b593
+  down (5.5.0) sha256=787e14fcfe7824b8cac676c608359e4083b2e4d6e1d3b1745b79f27bcf931585
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
@@ -619,9 +638,15 @@ CHECKSUMS
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
+  ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
+  ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
+  ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86-linux-gnu) sha256=38e150df5f4ca555e25beca4090823ae09657bceded154e3c52f8631c1ed72cf
+  ffi (1.17.4-x86-linux-musl) sha256=fbeec0fc7c795bcf86f623bb18d31ea1820f7bd580e1703a3d3740d527437809
   ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   gapic-common (1.1.0) sha256=3270ab3c5135012a4ab4d8848f945cf35014192f24504cdb40c66fc67f1beaa3
   get_process_mem (0.2.7) sha256=4afd3c3641dd6a817c09806c7d6d509d8a9984512ac38dea8b917426bbf77eba
@@ -635,6 +660,7 @@ CHECKSUMS
   google-protobuf (3.25.3) sha256=39bd97cbc7631905e76cdf8f1bf3dda1c3d05200d7e23f575aced78930fbddd6
   google-protobuf (3.25.3-aarch64-linux) sha256=5ea9d20d60e5d3bef8d881b426946345e5ac6cf4779ac81cd900e45f40567243
   google-protobuf (3.25.3-arm64-darwin) sha256=c42cddd21c4f09fd756fe0efd70ab6c8006dd67ffbb04e99fe7310f49923d18c
+  google-protobuf (3.25.3-x86-linux) sha256=7a0e74f14affbce6024595cdb55e7e8c5a51716f0bb11b103c63cbe3a3a0e348
   google-protobuf (3.25.3-x86_64-darwin) sha256=13d27e96e89835f642c444e32414fd50fabc29a125d78760ad067d6536214f02
   google-protobuf (3.25.3-x86_64-linux) sha256=ceeba879d9313a2bd0600a97d6fe3cf529a9b37d12ca026f891996c118b7ffb2
   googleapis-common-protos (1.8.0) sha256=bfe89cb75d1a8f13e4591d262a20333e145481d803adb74dd13ac0517decdffe
@@ -643,6 +669,7 @@ CHECKSUMS
   grpc (1.70.1) sha256=174594605c96df3caed44a83221665aa6e11f554e56028f89bef82c07ffb83cb
   grpc (1.70.1-aarch64-linux) sha256=48e0b22b8b96e61ca7054a7fea894a4845498e6bf366b50eff03e588f714ed96
   grpc (1.70.1-arm64-darwin) sha256=eeb6758dd58135e4e5fcd78726b9a18d34d7313e41bc81528ff4b3dce65cf525
+  grpc (1.70.1-x86-linux) sha256=cb7921614fec4f90f888637736b7ede85305ad94a869f736176f9ebede98c4f1
   grpc (1.70.1-x86_64-darwin) sha256=628cb929542c277b6e5f638b6b8575b3bdcde250a2a70bddf8c0be1bf77e6781
   grpc (1.70.1-x86_64-linux) sha256=ed12eea749127119c9761a58ba17ce92aadbc35b0b4fa27e4bd8ec84047d63be
   haml (5.2.2) sha256=6e759246556145642ef832d670fc06f9bd8539159a0e600847a00291dd7aae0c
@@ -683,7 +710,7 @@ CHECKSUMS
   net-ftp (0.3.9) sha256=307817ccf7f428f79d083f7e36dbb46a9d1d375e0d23027824de1866f0b13b65
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   net-http-persistent (4.0.8) sha256=ef3de8319d691537b329053fae3a33195f8b070bbbfae8bf1a58c796081960e6
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d

--- a/controllers/users_controller.rb
+++ b/controllers/users_controller.rb
@@ -57,7 +57,7 @@ class UsersController < ApplicationController
       end
     end
 
-    # Display all users
+    # Display users
     get do
       check_last_modified_collection(User)
       reply get_users

--- a/helpers/properties_search_helper.rb
+++ b/helpers/properties_search_helper.rb
@@ -46,6 +46,10 @@ module Sinatra
         onts.select! { |o| ont_type = o.ontologyType.nil? ? "ONTOLOGY" : o.ontologyType.get_code_from_id; ontology_types.include?(ont_type) } unless ontology_types.empty?
         acronyms = restricted_ontologies_to_acronyms(params, onts)
         filter_query = get_terms_field_query_param(acronyms, "submissionAcronym")
+        # No acronym restriction: provide Solr's match-all literal so the
+        # subsequent `filter_query << " AND <clause>"` appends produce a
+        # well-formed `fq` instead of starting with a stray AND.
+        filter_query = "*:*" if filter_query.empty?
 
         ontology_types_clause = ontology_types.empty? ? "" : get_quoted_field_query_param(ontology_types, "OR", "ontologyType")
         filter_query = "#{filter_query} AND #{ontology_types_clause}" unless (ontology_types_clause.empty?)

--- a/helpers/search_helper.rb
+++ b/helpers/search_helper.rb
@@ -158,6 +158,10 @@ module Sinatra
         onts.select! { |o| ont_type = o.ontologyType.nil? ? "ONTOLOGY" : o.ontologyType.get_code_from_id; ontology_types.include?(ont_type) } unless ontology_types.empty?
         acronyms = restricted_ontologies_to_acronyms(params, onts)
         filter_query = get_terms_field_query_param(acronyms, "submissionAcronym")
+        # No acronym restriction: provide Solr's match-all literal so the
+        # subsequent `filter_query << " AND <clause>"` appends produce a
+        # well-formed `fq` instead of starting with a stray AND.
+        filter_query = "*:*" if filter_query.empty?
 
         # add subtree filter query if not empty
         filter_query << subtree_filter_query

--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -4,7 +4,7 @@ module Sinatra
   module Helpers
     module UsersHelper
       def get_users
-        attributes, page, size, _, _ = settings_params(LinkedData::Models::User)
+        attributes, page, size, order_by, _ = settings_params(LinkedData::Models::User)
         query = User.where.include(attributes)
 
         if params['search']
@@ -12,7 +12,8 @@ module Sinatra
           query = query.filter(filter)
         end
 
-        query = query.page(page, size) if page?
+        query = query.order_by(order_by || { username: :asc })
+        query = query.page(page, size)
 
         query.all
       end

--- a/test/controllers/test_properties_search_controller.rb
+++ b/test/controllers/test_properties_search_controller.rb
@@ -76,4 +76,14 @@ class TestPropertiesSearchController < TestCase
     results = MultiJson.load(last_response.body)
     assert_equal 2, results["collection"].length
   end
+
+  # Regression: same empty-acronym Solr fq bug as in /search — when
+  # ontology_types filters all candidates out, filter_query was "" and
+  # the subsequent " AND <clause>" appends produced a malformed fq.
+  def test_property_search_with_empty_acronym_filter_returns_ok
+    get '/property_search?q=anything&ontology_types=NONEXISTENT_TYPE'
+    assert last_response.ok?, "expected 200, got #{last_response.status}: #{last_response.body[0, 200]}"
+    results = MultiJson.load(last_response.body)
+    assert_equal 0, results["collection"].length
+  end
 end

--- a/test/controllers/test_search_controller.rb
+++ b/test/controllers/test_search_controller.rb
@@ -101,6 +101,18 @@ class TestSearchController < TestCase
     end
   end
 
+  # Regression: when the acronyms list filters down to empty (here via an
+  # ontology_types filter that matches no seeded ontology), the Solr fq used
+  # to start with " AND obsolete:false ..." — a malformed query rejected by
+  # Solr (400) and surfaced as 500 by the API. Fix substitutes Solr's
+  # match-all literal so the AND'd clauses concatenate cleanly.
+  def test_search_with_empty_acronym_filter_returns_ok
+    get "/search?q=anything&ontology_types=NONEXISTENT_TYPE"
+    assert last_response.ok?, "expected 200, got #{last_response.status}: #{last_response.body[0, 200]}"
+    results = MultiJson.load(last_response.body)
+    assert_equal 0, results["collection"].length
+  end
+
   def test_search_other_filters
     acronym = "MCCLSEARCHTEST-0"
     get "/search?q=receptor%20antagonists&ontologies=#{acronym}&require_exact_match=true"

--- a/test/controllers/test_users_controller.rb
+++ b/test/controllers/test_users_controller.rb
@@ -35,9 +35,29 @@ class TestUsersController < TestCase
   def test_all_users
     get '/users'
     assert last_response.ok?
-    users = MultiJson.load(last_response.body)
+    users_page = MultiJson.load(last_response.body)
+    users = users_page["collection"]
+    assert_equal 1, users_page["page"]
     assert users.any? {|u| u["username"].eql?("fred")}
-    assert users.length >= @@usernames.length
+    assert users_page["totalCount"] >= @@usernames.length
+  end
+
+  def test_all_users_pagination
+    get '/users?pagesize=2'
+    assert last_response.ok?
+    users_page = MultiJson.load(last_response.body)
+    assert_equal 1, users_page["page"]
+    assert_equal 2, users_page["collection"].length
+    assert_equal 2, users_page["nextPage"]
+  end
+
+  def test_all_users_include_all_is_paged
+    get '/users?include=all&pagesize=2'
+    assert last_response.ok?
+    users_page = MultiJson.load(last_response.body)
+    assert_equal 1, users_page["page"]
+    assert_equal 2, users_page["collection"].length
+    assert users_page["collection"].all? { |u| u.key?("created") }
   end
 
   def test_single_user


### PR DESCRIPTION
## Summary
- Force pagination on `GET /users` by removing the `if page?` guard in `helpers/users_helper.rb`. The endpoint now always returns a paged response (`{page, pageCount, totalCount, prevPage, nextPage, links, collection}`), never a flat array.
- Add a deterministic default sort (`username asc`) so clients walking `nextPage` links get stable page boundaries.
- Bump `ontologies_linked_data` to develop tip (`cdbf8f6`), which includes ncbo/ontologies_linked_data#286 — idempotent `User#admin?` and inverse-attribute exclusion from the auth-middleware load (the dominant per-user cost in the timeout).
- **Also fixes** `/search` and `/property_search` returning 500 when the acronym filter resolves to empty (e.g. `ontology_types` filter rejects all candidates, or the requesting user has no access to any of the requested ontologies). Pre-existing regression introduced by commit `388d1bd0` ("converted acronyms filter from Boolean to Term syntax"). Bundled here because both are production-critical and shipping in the same release window.

## Why /users is slow
Production users were unable to create ontologies, with `Faraday::TimeoutError` coming back from `bioportal_web_ui` controllers that called `LinkedData::Client::Models::User.all`. Response time of `/users?include=all` grew linearly with user count: every serialized user re-invoked `Thread.current[:remote_user]&.admin?`, which re-loaded `:role` via Goo on each call (N+1 over a single user), compounded by the absence of pagination. With ~5,300 users in production, this exceeded Faraday's 60s read timeout on every authenticated request.

## Why /search and /property_search are broken
Commit `388d1bd0` replaced `get_quoted_field_query_param` with `get_terms_field_query_param` at the start of `filter_query` construction. The new term-syntax function correctly early-returns `""` for an empty acronyms list (an empty `_query_:"{!terms f=…}"` would itself be malformed), but the rest of `filter_query` construction implicitly relied on the prior function's vacuous `submissionAcronym:""` placeholder always producing a non-empty starting clause.

When acronyms filtered to empty, `filter_query` was `""` and the subsequent `<< \" AND <clause>\"` appends produced a stray-AND `fq` that Solr rejected with 400 (surfaced as 500 by the API). Same bug at two call sites: `helpers/search_helper.rb:160` and `helpers/properties_search_helper.rb:48`. A third call site (`search_helper.rb:181`, valueset_root_ids) is unaffected — already guarded by `unless valueset_root_ids.empty?`.

Fix: substitute Solr's match-all literal `*:*` when `filter_query` is empty after the acronyms step. AND'ing further clauses onto `*:*` narrows correctly. Side benefit: this is also more correct than the pre-388d1bd0 behavior, which silently returned 0 hits when acronyms was empty due to the vacuously-restrictive `submissionAcronym:""` placeholder.

## Cross-repo rollout
The full /users fix spans four repos and must roll out in a specific order:
1. ✅ ncbo/ontologies_linked_data#286 (merged)
2. **This PR** — ontologies_api
3. ncbo/ontologies_api_ruby_client (companion PR — auto-flatten paged responses, slim User attrs)
4. ncbo/bioportal_web_ui — bump Gemfile.lock to the new client release (no controller code changes needed)

## Breaking change
`GET /users` now always returns a paged Hash, never a flat array. Direct HTTP consumers (anything bypassing the `ontologies_api_ruby_client` gem) need to read `response['collection']` instead of treating the response as an array. The forthcoming client release transparently walks pages and returns a flat array to existing in-process callers, so consumers using the gem are unaffected.

## Local benchmarks (21,339 users on dev triplestore, after #286 + this PR)
| Scenario | Before | After |
|---|---|---|
| Raw `/users?include=all` (no params, paginates to 50) | timeout | 2.0s |
| Raw `pagesize=5000` slim include | 155.7s | 2.1s |
| Raw `pagesize=5000&include=all` (6.7 MB) | ~9 min | 13.8s |
| `Models::User.all` walk via client (5 pages × 5000) | timeout | 44.8s |

Per-page cost dropped from ~30ms × N (linear) to roughly flat at ~2s for slim include.

## Test plan
- [ ] `bundle exec rake test` passes locally
- [ ] `test_all_users` asserts paged response shape (`page`, `totalCount`, `collection`)
- [ ] `test_all_users_pagination` asserts `?pagesize=2` returns page 1 of 2 with `nextPage=2`
- [ ] `test_all_users_include_all_is_paged` asserts `?include=all&pagesize=2` paginates and each item carries the requested attributes (e.g. `created`)
- [ ] `test_search_with_empty_acronym_filter_returns_ok` asserts `/search?q=anything&ontology_types=NONEXISTENT_TYPE` returns 200 with empty collection (regression for the `*:*` fix)
- [ ] `test_property_search_with_empty_acronym_filter_returns_ok` asserts the equivalent for `/property_search`
- [ ] Smoke test against staging: `curl '/users?include=all'` returns paged JSON; `curl '/users?pagesize=50&include=all'` returns first page in a few seconds; `curl '/search?q=Conceptual%20Entity&ontologies=STY&require_exact_match=true'` returns 200 (was 500)
- [ ] Verify `bioportal_web_ui` (with the matching client gem) renders `/admin/users`, the New Ontology form's user dropdown, and `/users` admin page correctly after deploy