### PR TITLE
Fix: trailing-slash 301 redirects downgrading https to http (#217)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_cron.git
-  revision: d92fd430629eb070ef5a2e01b4f613b3b1f05a5a
+  revision: 0d1532220408006bd8e28f5017523db00abc87b0
   branch: develop
   specs:
     ncbo_cron (0.0.1)
@@ -66,7 +66,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 24c5a6d0a9de0ec6510d2615cc2e98c93c370a4e
+  revision: cdbf8f6990f10181f3efa11afada051a8283978e
   branch: develop
   specs:
     ontologies_linked_data (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_cron.git
-  revision: 0d1532220408006bd8e28f5017523db00abc87b0
-  branch: develop
+  revision: 8e43d5c2a053accffe801ff523e14b29743a079a
+  branch: master
   specs:
     ncbo_cron (0.0.1)
       dante
@@ -66,8 +66,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: cdbf8f6990f10181f3efa11afada051a8283978e
-  branch: develop
+  revision: 32023829506089164a27da1e6aa05b901a019079
+  branch: master
   specs:
     ontologies_linked_data (0.0.1)
       activesupport

--- a/init.rb
+++ b/init.rb
@@ -22,9 +22,26 @@ Sinatra.register do
         app.public_send(http_verb, "#{pattern}/") do
           pass unless request.path_info.end_with?('/')
           redirect_path = request.path_info.chomp('/')
-          redirect redirect_path, 301
+          redirect canonical_redirect_url(redirect_path), 301
         end
       end
     end
+  end
+end
+
+helpers do
+  def canonical_redirect_url(path)
+    url = +"#{external_request_scheme}://#{request.host_with_port}#{path}"
+    url << "?#{request.query_string}" unless request.query_string.empty?
+    url
+  end
+
+  # Rack 3 no longer trusts X-Forwarded-Proto on `request.scheme`, so a
+  # TLS-terminating proxy that forwards to the app over HTTP would otherwise
+  # cause us to emit `Location: http://...` for an https:// request.
+  def external_request_scheme
+    forwarded = request.get_header('HTTP_X_FORWARDED_PROTO').to_s
+                       .split(',').first.to_s.strip.downcase
+    %w[http https].include?(forwarded) ? forwarded : request.scheme
   end
 end

--- a/test/controllers/test_home_controller.rb
+++ b/test/controllers/test_home_controller.rb
@@ -24,6 +24,59 @@ class TestHomeController < TestCase
     assert_match(/<html/i, last_response.body)
   end
 
+  # Regression: ncbo/ontologies_api#217
+  # Behind a TLS-terminating proxy, request.scheme is `http` under Rack 3,
+  # so the trailing-slash 301 was emitting `Location: http://...` for an
+  # https:// request and getting blocked as mixed content by the browser.
+  def test_trailing_slash_redirect_preserves_forwarded_https_scheme
+    get '/documentation/?apikey=test-key', {}, { 'HTTP_X_FORWARDED_PROTO' => 'https' }
+
+    assert_equal 301, last_response.status
+    assert_equal "https://#{last_request.host_with_port}/documentation?apikey=test-key",
+      last_response.headers['Location']
+  end
+
+  def test_trailing_slash_redirect_falls_back_to_request_scheme_without_forwarded_header
+    get '/documentation/'
+
+    assert_equal 301, last_response.status
+    assert_equal "http://#{last_request.host_with_port}/documentation",
+      last_response.headers['Location']
+  end
+
+  def test_trailing_slash_redirect_ignores_invalid_forwarded_proto
+    get '/documentation/', {}, { 'HTTP_X_FORWARDED_PROTO' => 'javascript' }
+
+    assert_equal 301, last_response.status
+    assert_equal "http://#{last_request.host_with_port}/documentation",
+      last_response.headers['Location']
+  end
+
+  # Per RFC 7239, a request that traversed multiple proxies appends to
+  # X-Forwarded-Proto as a comma-separated list (`https, http`); the leftmost
+  # value is the original client-facing scheme.
+  def test_trailing_slash_redirect_uses_first_value_in_chained_forwarded_proto
+    get '/documentation/', {}, { 'HTTP_X_FORWARDED_PROTO' => 'https, http' }
+
+    assert_equal 301, last_response.status
+    assert_equal "https://#{last_request.host_with_port}/documentation",
+      last_response.headers['Location']
+  end
+
+  # Regression: ncbo/ontologies_api#217 reproduction case. The bug was first
+  # observed against `/ontologies/:ont/classes/<encoded-IRI>/paths_to_root/`,
+  # so the encoded `%2F`s in the class IRI must round-trip through the redirect
+  # unchanged.
+  def test_trailing_slash_redirect_preserves_url_encoded_path_segments
+    encoded_cls = 'http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSTY%2FT071'
+    get "/ontologies/STY/classes/#{encoded_cls}/paths_to_root/?apikey=test-key",
+      {}, { 'HTTP_X_FORWARDED_PROTO' => 'https' }
+
+    assert_equal 301, last_response.status
+    assert_equal "https://#{last_request.host_with_port}/ontologies/STY/classes/#{encoded_cls}/paths_to_root?apikey=test-key",
+      last_response.headers['Location']
+  end
+
   # Regression: ncbo/ontologies_api#212 / #37
   # Valid `/metadata/:class` paths were 500-ing under sinatra-contrib 4.2.1
   # for the same namespace-helper-resolution reason as /documentation, and


### PR DESCRIPTION
## Summary

Fixes [#217](https://github.com/ncbo/ontologies_api/issues/217). Behind a TLS-terminating proxy under Rack 3, `request.scheme` returns `http` because `X-Forwarded-Proto` is no longer auto-trusted. Sinatra's `redirect` helper was expanding the relative target to an absolute URL using that scheme, so `https://` requests with a trailing slash got `Location: http://...` and were blocked as mixed content by browsers (e.g. biomixer's `/paths_to_root/` calls from bioportal.bioontology.org).

- Build the redirect URL explicitly in a helper, reading `X-Forwarded-Proto` for the scheme and falling back to `request.scheme` when the header is absent or not `http`/`https`.
- Host stays `request.host_with_port`. `X-Forwarded-Host` is **not** read — it isn't needed for the fix, and trusting it would widen the open-redirect surface if a proxy ever passed client-supplied values through.
- Also includes a `Gemfile.lock` bump for `ncbo_cron` and `ontologies_linked_data` (unrelated to this fix; carried over from the branch base).

## Test plan

Regression tests in `test/controllers/test_home_controller.rb` cover:

- [x] forwarded `https` scheme is preserved in `Location`
- [x] missing `X-Forwarded-Proto` falls back to `request.scheme`
- [x] invalid `X-Forwarded-Proto` (e.g. `javascript`) falls back to `request.scheme`
- [x] chained `X-Forwarded-Proto: https, http` uses the leftmost (client-facing) value
- [x] URL-encoded path segments (`%3A`/`%2F` in the class IRI from the issue's repro) round-trip through the redirect unchanged
- [x] query string is preserved on the redirect target

Verify in staging by curling a trailing-slash URL through the proxy and confirming `location: https://...` in the 301 response.
