### PR TITLE
Expand user search fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ test/data/ontology_files/repo/**/*
 # Claude Code
 .claude/
 
+# Serena
+.serena/
+
 *.swp
 
 config/environments/console.rb

--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -3,19 +3,29 @@ require 'sinatra/base'
 module Sinatra
   module Helpers
     module UsersHelper
+      USER_SEARCH_FIELDS = %i[username email firstName lastName].freeze
+
       def get_users
         attributes, page, size, order_by, _ = settings_params(LinkedData::Models::User)
         query = User.where.include(attributes)
 
         if params['search']
-          filter = Goo::Filter.new(:username).regex(params['search'])
-          query = query.filter(filter)
+          query = query.filter(user_search_filter(params['search']))
         end
 
         query = query.order_by(order_by || { username: :asc })
         query = query.page(page, size)
 
         query.all
+      end
+
+      def user_search_filter(term)
+        field, *remaining_fields = USER_SEARCH_FIELDS
+        filter = Goo::Filter.new(field).regex(term)
+        remaining_fields.each do |search_field|
+          filter = filter.or(Goo::Filter.new(search_field).regex(term))
+        end
+        filter
       end
 
       def filter_for_user_onts(obj)

--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -5,6 +5,7 @@ module Sinatra
     module UsersHelper
       USER_SEARCH_FIELDS = %i[username email firstName lastName].freeze
       DEFAULT_USER_SEARCH_FIELDS = %i[username].freeze
+      ALL_USER_SEARCH_FIELDS = 'all'
 
       def get_users
         attributes, page, size, order_by, _ = settings_params(LinkedData::Models::User)
@@ -32,8 +33,18 @@ module Sinatra
       def user_search_fields
         return DEFAULT_USER_SEARCH_FIELDS if params['search_fields'].blank?
 
-        fields = params['search_fields'].split(',').map(&:strip).reject(&:empty?).map(&:to_sym)
+        fields = params['search_fields'].split(',').map(&:strip).reject(&:empty?)
         return DEFAULT_USER_SEARCH_FIELDS if fields.empty?
+
+        return USER_SEARCH_FIELDS if fields == [ALL_USER_SEARCH_FIELDS]
+
+        if fields.include?(ALL_USER_SEARCH_FIELDS)
+          error_message = "Unsupported search_fields: #{params['search_fields']}. "
+          error_message += 'Use all by itself or list individual fields'
+          error 400, error_message
+        end
+
+        fields = fields.map(&:to_sym)
 
         unknown_fields = fields - USER_SEARCH_FIELDS
         unless unknown_fields.empty?

--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -31,29 +31,37 @@ module Sinatra
       end
 
       def user_search_fields
-        return DEFAULT_USER_SEARCH_FIELDS if params['search_fields'].blank?
-
-        fields = params['search_fields'].split(',').map(&:strip).reject(&:empty?)
+        fields = requested_user_search_fields
         return DEFAULT_USER_SEARCH_FIELDS if fields.empty?
 
+        validate_all_user_search_fields!(fields)
         return USER_SEARCH_FIELDS if fields == [ALL_USER_SEARCH_FIELDS]
 
-        if fields.include?(ALL_USER_SEARCH_FIELDS)
-          error_message = "Unsupported search_fields: #{params['search_fields']}. "
-          error_message += 'Use all by itself or list individual fields'
-          error 400, error_message
-        end
-
         fields = fields.map(&:to_sym)
-
-        unknown_fields = fields - USER_SEARCH_FIELDS
-        unless unknown_fields.empty?
-          unsupported_fields = unknown_fields.join(', ')
-          allowed_fields = USER_SEARCH_FIELDS.join(', ')
-          error 400, "Unsupported search_fields: #{unsupported_fields}. Allowed fields: #{allowed_fields}"
-        end
+        validate_known_user_search_fields!(fields)
 
         fields
+      end
+
+      def requested_user_search_fields
+        params['search_fields'].to_s.split(',').map(&:strip).reject(&:empty?)
+      end
+
+      def validate_all_user_search_fields!(fields)
+        return unless fields.include?(ALL_USER_SEARCH_FIELDS) && fields != [ALL_USER_SEARCH_FIELDS]
+
+        error_message = "Unsupported search_fields: #{params['search_fields']}. "
+        error_message += 'Use all by itself or list individual fields'
+        error 400, error_message
+      end
+
+      def validate_known_user_search_fields!(fields)
+        unknown_fields = fields - USER_SEARCH_FIELDS
+        return if unknown_fields.empty?
+
+        unsupported_fields = unknown_fields.join(', ')
+        allowed_fields = USER_SEARCH_FIELDS.join(', ')
+        error 400, "Unsupported search_fields: #{unsupported_fields}. Allowed fields: #{allowed_fields}"
       end
 
       def filter_for_user_onts(obj)

--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -4,6 +4,7 @@ module Sinatra
   module Helpers
     module UsersHelper
       USER_SEARCH_FIELDS = %i[username email firstName lastName].freeze
+      DEFAULT_USER_SEARCH_FIELDS = %i[username].freeze
 
       def get_users
         attributes, page, size, order_by, _ = settings_params(LinkedData::Models::User)
@@ -20,12 +21,28 @@ module Sinatra
       end
 
       def user_search_filter(term)
-        field, *remaining_fields = USER_SEARCH_FIELDS
+        field, *remaining_fields = user_search_fields
         filter = Goo::Filter.new(field).regex(term)
         remaining_fields.each do |search_field|
           filter = filter.or(Goo::Filter.new(search_field).regex(term))
         end
         filter
+      end
+
+      def user_search_fields
+        return DEFAULT_USER_SEARCH_FIELDS if params['search_fields'].blank?
+
+        fields = params['search_fields'].split(',').map(&:strip).reject(&:empty?).map(&:to_sym)
+        return DEFAULT_USER_SEARCH_FIELDS if fields.empty?
+
+        unknown_fields = fields - USER_SEARCH_FIELDS
+        unless unknown_fields.empty?
+          unsupported_fields = unknown_fields.join(', ')
+          allowed_fields = USER_SEARCH_FIELDS.join(', ')
+          error 400, "Unsupported search_fields: #{unsupported_fields}. Allowed fields: #{allowed_fields}"
+        end
+
+        fields
       end
 
       def filter_for_user_onts(obj)

--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -5,7 +5,7 @@ module Sinatra
     module UsersHelper
       USER_SEARCH_FIELDS = %i[username email firstName lastName].freeze
       DEFAULT_USER_SEARCH_FIELDS = %i[username].freeze
-      ALL_USER_SEARCH_FIELDS = 'all'
+      ALL_USER_SEARCH_FIELDS = 'all'.freeze
 
       def get_users
         attributes, page, size, order_by, _ = settings_params(LinkedData::Models::User)
@@ -58,14 +58,14 @@ module Sinatra
 
       def filter_for_user_onts(obj)
         return obj unless obj.is_a?(Enumerable)
-        return obj unless env["REMOTE_USER"]
-        return obj if env["REMOTE_USER"].customOntology.empty?
-        return obj if params["ignore_custom_ontologies"]
+        return obj unless env['REMOTE_USER']
+        return obj if env['REMOTE_USER'].customOntology.empty?
+        return obj if params['ignore_custom_ontologies']
 
-        user = env["REMOTE_USER"]
+        user = env['REMOTE_USER']
 
         if obj.first.is_a?(LinkedData::Models::Ontology)
-          obj = obj.select {|o| user.custom_ontology_id_set.include?(o.id.to_s)}
+          obj = obj.select { |o| user.custom_ontology_id_set.include?(o.id.to_s) }
         end
 
         obj
@@ -73,7 +73,7 @@ module Sinatra
 
       def send_reset_token(email, username)
         user = LinkedData::Models::User.where(email: email, username: username).include(LinkedData::Models::User.attributes).first
-        error 404, "User not found" unless user
+        error 404, 'User not found' unless user
         reset_token = token(36)
         user.resetToken = reset_token
         user.resetTokenExpireTime = Time.now.to_i + 1.hours.to_i
@@ -84,22 +84,22 @@ module Sinatra
       end
 
       def token(len)
-        chars = ("a".."z").to_a + ("A".."Z").to_a + ("1".."9").to_a
-        token = ""
-        1.upto(len) { |i| token << chars[rand(chars.size-1)] }
+        chars = ('a'..'z').to_a + ('A'..'Z').to_a + ('1'..'9').to_a
+        token = ''
+        1.upto(len) { |i| token << chars[rand(chars.size - 1)] }
         token
       end
 
       def reset_password(email, username, token)
         user = LinkedData::Models::User.where(email: email, username: username).include(User.goo_attrs_to_load(includes_param) + [:resetToken, :passwordHash, :resetTokenExpireTime]).first
 
-        error 404, "User not found" unless user
+        error 404, 'User not found' unless user
 
         user.show_apikey = true
         token_accepted = token.eql?(user.resetToken)
         if token_accepted
-          error 401, "Invalid password reset token" if user.resetTokenExpireTime.nil?
-          error 401, "The password reset token expired" if user.resetTokenExpireTime < Time.now.to_i
+          error 401, 'Invalid password reset token' if user.resetTokenExpireTime.nil?
+          error 401, 'The password reset token expired' if user.resetTokenExpireTime < Time.now.to_i
           user.resetToken = nil
           user.resetTokenExpireTime = nil
           user.save(override_security: true) if user.valid?
@@ -110,20 +110,20 @@ module Sinatra
       end
 
       def oauth_authenticate(params)
-        access_token  = params["access_token"]
-        provider  = params["token_provider"]
+        access_token = params['access_token']
+        provider = params['token_provider']
         user = LinkedData::Models::User.oauth_authenticate(access_token, provider)
-        error 401, "Access token invalid"if user.nil?
+        error 401, 'Access token invalid' if user.nil?
         user
       end
 
       def login_password_authenticate(params)
-        user_id       = params["user"]
-        user_password = params["password"]
+        user_id       = params['user']
+        user_password = params['password']
         user = User.find(user_id).include(User.goo_attrs_to_load(includes_param) + [:passwordHash]).first
         authenticated = false
         authenticated = user.authenticate(user_password) unless user.nil?
-        error 401, "Username/password combination invalid" unless authenticated
+        error 401, 'Username/password combination invalid' unless authenticated
 
         user
       end

--- a/test/controllers/test_users_controller.rb
+++ b/test/controllers/test_users_controller.rb
@@ -89,7 +89,7 @@ class TestUsersController < TestCase
   end
 
   def test_search_users_by_email
-    users_page = search_users('mailmarker', search_fields: 'username,email,firstName,lastName')
+    users_page = search_users('mailmarker', search_fields: 'all')
     usernames = users_page['collection'].map { |user| user['username'] }
 
     assert_equal ['email_account'], usernames
@@ -98,7 +98,7 @@ class TestUsersController < TestCase
   end
 
   def test_search_users_by_first_name
-    users_page = search_users('given_marker', search_fields: 'username,email,firstName,lastName')
+    users_page = search_users('given_marker', search_fields: 'all')
     usernames = users_page['collection'].map { |user| user['username'] }
 
     assert_equal ['first_name_account'], usernames
@@ -107,7 +107,7 @@ class TestUsersController < TestCase
   end
 
   def test_search_users_by_last_name
-    users_page = search_users('family_marker', search_fields: 'username,email,firstName,lastName')
+    users_page = search_users('family_marker', search_fields: 'all')
     usernames = users_page['collection'].map { |user| user['username'] }
 
     assert_equal ['last_name_account'], usernames
@@ -116,11 +116,17 @@ class TestUsersController < TestCase
   end
 
   def test_search_users_no_match
-    users_page = search_users('not_a_search_match', search_fields: 'username,email,firstName,lastName')
+    users_page = search_users('not_a_search_match', search_fields: 'all')
 
     assert_equal [], users_page['collection']
     assert_equal 0, users_page['totalCount']
     assert_equal 0, users_page['pageCount']
+  end
+
+  def test_search_users_rejects_all_with_other_fields
+    get '/users', search: 'mailmarker', search_fields: 'all,email'
+
+    assert_equal 400, last_response.status
   end
 
   def test_single_user

--- a/test/controllers/test_users_controller.rb
+++ b/test/controllers/test_users_controller.rb
@@ -80,8 +80,16 @@ class TestUsersController < TestCase
     assert_equal 1, users_page['pageCount']
   end
 
-  def test_search_users_by_email
+  def test_search_users_defaults_to_username_only
     users_page = search_users('mailmarker')
+
+    assert_equal [], users_page['collection']
+    assert_equal 0, users_page['totalCount']
+    assert_equal 0, users_page['pageCount']
+  end
+
+  def test_search_users_by_email
+    users_page = search_users('mailmarker', search_fields: 'username,email,firstName,lastName')
     usernames = users_page['collection'].map { |user| user['username'] }
 
     assert_equal ['email_account'], usernames
@@ -90,7 +98,7 @@ class TestUsersController < TestCase
   end
 
   def test_search_users_by_first_name
-    users_page = search_users('given_marker')
+    users_page = search_users('given_marker', search_fields: 'username,email,firstName,lastName')
     usernames = users_page['collection'].map { |user| user['username'] }
 
     assert_equal ['first_name_account'], usernames
@@ -99,7 +107,7 @@ class TestUsersController < TestCase
   end
 
   def test_search_users_by_last_name
-    users_page = search_users('family_marker')
+    users_page = search_users('family_marker', search_fields: 'username,email,firstName,lastName')
     usernames = users_page['collection'].map { |user| user['username'] }
 
     assert_equal ['last_name_account'], usernames
@@ -108,7 +116,7 @@ class TestUsersController < TestCase
   end
 
   def test_search_users_no_match
-    users_page = search_users('not_a_search_match')
+    users_page = search_users('not_a_search_match', search_fields: 'username,email,firstName,lastName')
 
     assert_equal [], users_page['collection']
     assert_equal 0, users_page['totalCount']
@@ -298,8 +306,11 @@ class TestUsersController < TestCase
     LinkedData::Models::User.find(@@username).first&.delete
   end
 
-  def search_users(term)
-    get '/users', search: term, pagesize: 100
+  def search_users(term, search_fields: nil)
+    query_params = { search: term, pagesize: 100 }
+    query_params[:search_fields] = search_fields if search_fields
+
+    get '/users', query_params
     assert last_response.ok?
     MultiJson.load(last_response.body)
   end

--- a/test/controllers/test_users_controller.rb
+++ b/test/controllers/test_users_controller.rb
@@ -10,6 +10,17 @@ class TestUsersController < TestCase
       User.new(username: username, email: "#{username}@example.org", password: "pass_word").save
     end
 
+    search_users = [
+      { username: 'username_marker_account', email: 'search@example.org', firstName: 'Username', lastName: 'Search' },
+      { username: 'email_account', email: 'mailmarker@example.org', firstName: 'Email', lastName: 'Search' },
+      { username: 'first_name_account', email: 'search@example.org', firstName: 'given_marker', lastName: 'Search' },
+      { username: 'last_name_account', email: 'search@example.org', firstName: 'Last', lastName: 'family_marker' }
+    ]
+
+    @@users.concat(search_users.map do |user_params|
+      User.new(user_params.merge(password: 'pass_word')).save
+    end)
+
     # Test data
     @@username = "test_user"
   end
@@ -58,6 +69,50 @@ class TestUsersController < TestCase
     assert_equal 1, users_page["page"]
     assert_equal 2, users_page["collection"].length
     assert users_page["collection"].all? { |u| u.key?("created") }
+  end
+
+  def test_search_users_by_username
+    users_page = search_users('username_marker')
+    usernames = users_page['collection'].map { |user| user['username'] }
+
+    assert_equal ['username_marker_account'], usernames
+    assert_equal 1, users_page['totalCount']
+    assert_equal 1, users_page['pageCount']
+  end
+
+  def test_search_users_by_email
+    users_page = search_users('mailmarker')
+    usernames = users_page['collection'].map { |user| user['username'] }
+
+    assert_equal ['email_account'], usernames
+    assert_equal 1, users_page['totalCount']
+    assert_equal 1, users_page['pageCount']
+  end
+
+  def test_search_users_by_first_name
+    users_page = search_users('given_marker')
+    usernames = users_page['collection'].map { |user| user['username'] }
+
+    assert_equal ['first_name_account'], usernames
+    assert_equal 1, users_page['totalCount']
+    assert_equal 1, users_page['pageCount']
+  end
+
+  def test_search_users_by_last_name
+    users_page = search_users('family_marker')
+    usernames = users_page['collection'].map { |user| user['username'] }
+
+    assert_equal ['last_name_account'], usernames
+    assert_equal 1, users_page['totalCount']
+    assert_equal 1, users_page['pageCount']
+  end
+
+  def test_search_users_no_match
+    users_page = search_users('not_a_search_match')
+
+    assert_equal [], users_page['collection']
+    assert_equal 0, users_page['totalCount']
+    assert_equal 0, users_page['pageCount']
   end
 
   def test_single_user
@@ -241,6 +296,12 @@ class TestUsersController < TestCase
 
   def _delete_user(username)
     LinkedData::Models::User.find(@@username).first&.delete
+  end
+
+  def search_users(term)
+    get '/users', search: term, pagesize: 100
+    assert last_response.ok?
+    MultiJson.load(last_response.body)
   end
 
   def _create_admin_user(apikey: nil)

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -29,7 +29,11 @@ require 'multi_json'
 require 'oj'
 require 'json-schema'
 require 'minitest/reporters'
-Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new(:color => true), Minitest::Reporters::MeanTimeReporter.new]
+unless ENV['RM_INFO']
+  Minitest::Reporters.use! [
+    Minitest::Reporters::SpecReporter.new(color: true),
+    Minitest::Reporters::MeanTimeReporter.new]
+end
 MAX_TEST_REDIS_SIZE = 10_000
 
 # Check to make sure you want to run if not pointed at localhost


### PR DESCRIPTION
## Summary
- Preserve existing `/users?search=` behavior: default search remains username-only for backward compatibility.
- Add optional `search_fields` param so clients can opt into searching specific fields: `username`, `email`, `firstName`, and/or `lastName`.
- Add `search_fields=all` shorthand for searching all supported user search fields.
- Reject mixed `all` values such as `search_fields=all,email`; `all` must be used by itself.
- Add users controller tests for the username-only default, opt-in broad search, strict `all` handling, and no-match pagination metadata.
- Skip `Minitest::Reporters` when tests are launched from RubyMine so IDE test runs can use RubyMine's reporter.
- Fix some RuboCop warnings

## Notes
BioPortal Admin Users can pass `search_fields=all` to search across all user table fields. Existing clients, including remote account pickers that expect username-only matching, can omit `search_fields`.

## Verification
- `ruby -c helpers/users_helper.rb`
- `ruby -c test/controllers/test_users_controller.rb`
- `bundle exec ruby test/controllers/test_users_controller.rb`

Closes #225