### PR TITLE
Fix: incorrect search result rankings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,12 +50,12 @@ gem 'rack-contrib'
 gem 'kramdown'
 
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', github: 'ncbo/goo', branch: 'development'
+gem 'goo', github: 'ncbo/goo', branch: 'fix/incorrect-search-result-ranking'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'development'
 gem 'ncbo_annotator', github: 'ncbo/ncbo_annotator', branch: 'develop'
-gem 'ncbo_cron', github: 'ncbo/ncbo_cron', branch: 'develop'
+gem 'ncbo_cron', github: 'ncbo/ncbo_cron', branch: 'fix/incorrect-search-result-ranking'
 gem 'ncbo_ontology_recommender', github: 'ncbo/ncbo_ontology_recommender', branch: 'develop'
-gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'develop'
+gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'fix/incorrect-search-result-ranking'
 
 group :development do
   gem 'shotgun', github: 'syphax-bouazzouni/shotgun', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 5c3a3aca915ebed7cd4ca70be049889756eb47da
+  revision: 684fbe06f8dd9daad10010dc460e06c7ad3a946c
   branch: fix/incorrect-search-result-ranking
   specs:
     goo (0.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 28329ce66ca724ba3652576938e9dc219ca496bf
-  branch: development
+  revision: 5c3a3aca915ebed7cd4ca70be049889756eb47da
+  branch: fix/incorrect-search-result-ranking
   specs:
     goo (0.0.2)
       addressable (~> 2.8)
@@ -37,8 +37,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_cron.git
-  revision: 5b54b269fdf7f0ced79a86700b7649a1f38df31c
-  branch: develop
+  revision: 6a5bf495e8cb7d403d1e1864b198c2d9d415214e
+  branch: fix/incorrect-search-result-ranking
   specs:
     ncbo_cron (0.0.1)
       dante
@@ -66,8 +66,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 1d0acc3e0e91fb6e0c1ffb393a0e5fdbe481d6e2
-  branch: develop
+  revision: 4561b0423465324bd7d84e042f721ab7b144e9e3
+  branch: fix/incorrect-search-result-ranking
   specs:
     ontologies_linked_data (0.0.1)
       activesupport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 4561b0423465324bd7d84e042f721ab7b144e9e3
+  revision: a1627e10e9367633dc5b7390fe1da7f11be2d642
   branch: fix/incorrect-search-result-ranking
   specs:
     ontologies_linked_data (0.0.1)

--- a/helpers/search_helper.rb
+++ b/helpers/search_helper.rb
@@ -291,7 +291,7 @@ module Sinatra
         doc.each do |k, v|
           attr, lang = k.to_s.split('_')
 
-          next if [:ontology_rank, :resource_id, :resource_model].include?(k)
+          next if [:resource_id, :resource_model].include?(k)
           next if lang.blank? || attr.blank?
           next if !(request_languages + %w[none]).include?(lang) && !request_all_languages?
 
@@ -566,7 +566,6 @@ module Sinatra
         resp = LinkedData::Models::Class.search(query, params)
         total_found = resp["response"]["numFound"]
         add_matched_fields(resp, Sinatra::Helpers::SearchHelper::MATCH_TYPE_PREFLABEL)
-        ontology_rank = LinkedData::Models::Ontology.rank
 
         resp["response"]["docs"].each do |doc|
           doc = doc.symbolize_keys
@@ -582,7 +581,6 @@ module Sinatra
           ontology = LinkedData::Models::Ontology.read_only(id: ontology_uri, acronym: doc[:submissionAcronym])
           submission = LinkedData::Models::OntologySubmission.read_only(id: doc[:ontologyId], ontology: ontology)
           doc[:submission] = submission
-          doc[:ontology_rank] = (ontology_rank[doc[:submissionAcronym]] && !ontology_rank[doc[:submissionAcronym]].empty?) ? ontology_rank[doc[:submissionAcronym]][:normalizedScore] : 0.0
           doc[:properties] = MultiJson.load(doc.delete(:propertyRaw)) if include_param_contains?(:properties)
 
           doc = filter_attrs_by_language(doc)

--- a/helpers/search_helper.rb
+++ b/helpers/search_helper.rb
@@ -88,6 +88,7 @@ module Sinatra
         params["stopwords"] = "true"
         params["lowercaseOperators"] = "true"
         params["fl"] = "*,score"
+        params["boost"] = "sum(ontologyRank,1)"
         params[INCLUDE_VIEWS_PARAM] = params[ALSO_SEARCH_VIEWS] if params[ALSO_SEARCH_VIEWS]
 
         # highlighting is used to determine the field that got matched, NCBO-974

--- a/helpers/search_helper.rb
+++ b/helpers/search_helper.rb
@@ -591,14 +591,6 @@ module Sinatra
           docs.push(instance)
         end
 
-        unless params['sort']
-          if !text.nil? && text[-1] == '*'
-            docs.sort! { |a, b| [b[:score], a[:prefLabelExact].downcase, b[:ontology_rank]] <=> [a[:score], b[:prefLabelExact].downcase, a[:ontology_rank]] }
-          else
-            docs.sort! { |a, b| [b[:score], b[:ontology_rank]] <=> [a[:score], a[:ontology_rank]] }
-          end
-        end
-
         page_object(docs, total_found)
       end
 

--- a/test/controllers/test_search_controller.rb
+++ b/test/controllers/test_search_controller.rb
@@ -101,53 +101,29 @@ class TestSearchController < TestCase
     end
   end
 
-  def test_search_rank_uses_case_insensitive_exact_match_before_page_sorting
-    ranked_ontologies = [
-      ["RANKHIGH", 1.0, "./test/data/ontology_files/search_rank_melanoma_upper.owl"],
-      ["RANKMIDHI", 0.7, "./test/data/ontology_files/search_rank_melanoma_lower.owl"],
-      ["RANKMIDLO", 0.4, "./test/data/ontology_files/search_rank_melanoma_lower.owl"],
-      ["RANKLOW", 0.1, "./test/data/ontology_files/search_rank_melanoma_lower.owl"]
-    ]
-    ranking = ranked_ontologies.to_h do |acronym, bioportal_score, _|
-      [acronym, { bioportalScore: bioportal_score, umlsScore: 0.0 }]
-    end
-    rank_redis = Redis.new(host: LinkedData.settings.ontology_analytics_redis_host,
-                           port: LinkedData.settings.ontology_analytics_redis_port,
-                           timeout: 30)
-
-    begin
-      rank_redis.set(LinkedData::Models::Ontology::ONTOLOGY_RANK_REDIS_FIELD, Marshal.dump(ranking))
-
-      rank_search_process_options = {
-        process_rdf: true,
-        extract_metadata: false,
-        generate_missing_labels: false,
-        run_metrics: false,
-        reasoning: false,
-        index_search: true,
-        index_properties: false
-      }
-
-      ranked_ontologies.each do |acronym, _, file_path|
-        LinkedData::SampleData::Ontology.create_ontologies_and_submissions({
-          process_submission: true,
-          process_options: rank_search_process_options,
-          acronym: acronym,
-          acronym_suffix: "",
-          name: "#{acronym} Search Test",
-          file_path: file_path,
-          ont_count: 1,
-          submission_count: 1
-        })
-      end
-
+  # Phase 1 invariant: prefLabelExact and synonymExact use the string_ci
+  # field type so a lowercase query matches a mixed-case stored label.
+  # The schemaless-to-static migration regressed this field type to plain
+  # `string`, breaking lowercase searches for terms like "melanoma" against
+  # docs whose prefLabel was "Melanoma". This test exercises only the
+  # schema/case-insensitive fix; the rank-ordering boost is verified
+  # separately in test_search_rank_orders_results_via_solr_side_boost.
+  def test_schema_uses_case_insensitive_string_ci_exact_fields
+    with_ranked_melanoma_ontologies([
+      ["RANKHIGH", 1.0, "./test/data/ontology_files/search_rank_melanoma_upper.owl"]
+    ]) do
       schema = Goo.search_client(:term_search).fetch_schema
       pref_label_exact = schema["fields"].find { |field| field["name"] == "prefLabelExact" }
       synonym_exact = schema["fields"].find { |field| field["name"] == "synonymExact" }
 
-      assert_equal "string_ci", pref_label_exact["type"]
-      assert_equal "string_ci", synonym_exact["type"]
+      assert_equal "string_ci", pref_label_exact["type"],
+                   "prefLabelExact must be string_ci so lowercase queries match mixed-case stored labels"
+      assert_equal "string_ci", synonym_exact["type"],
+                   "synonymExact must be string_ci for the same case-insensitive guarantee"
 
+      # Lowercase query against RANKHIGH, whose prefLabel is "Melanoma".
+      # With string_ci this returns 1; with the pre-fix plain `string` type
+      # it would return 0 and the original ranking regression would surface.
       exact_match_resp = LinkedData::Models::Class.search(
         'prefLabelExact:"melanoma"',
         {
@@ -156,22 +132,48 @@ class TestSearchController < TestCase
           rows: 10
         }
       )
-      assert_equal 1, exact_match_resp["response"]["numFound"]
+      assert_equal 1, exact_match_resp["response"]["numFound"],
+                   "lowercase 'melanoma' must match mixed-case 'Melanoma' via string_ci prefLabelExact"
+    end
+  end
 
+  # Phase 2 mechanism: BioPortal ontology rank participates in Solr scoring
+  # via boost=sum(ontologyRank,1) BEFORE pagination. Seeds four ontologies
+  # with synthetic ranks (1.0, 0.7, 0.4, 0.1) and queries with pagesize=3.
+  # Expects the three returned acronyms to be the three highest-ranked, in
+  # rank order, with the lowest-ranked excluded from page 1 but still
+  # counted in totalCount.
+  #
+  # This passes deterministically only because the Solr-side boost multiplies
+  # each doc's intrinsic score by (1 + rank), producing distinct combined
+  # scores (2.0x, 1.7x, 1.4x, 1.1x). Without the boost — and given that the
+  # post-hoc Ruby tiebreaker has been removed — the four near-identical-score
+  # docs would tie at the Solr layer and which three landed on page 1 would
+  # be governed by Solr's internal tie-breaking, not by ontology rank.
+  #
+  # Coverage gap (deferred): with only 4 fixtures this does not exercise the
+  # original issue #230 failure mode where high-rank docs are stranded beyond
+  # Solr's first page (50+ matching docs would be needed to force that).
+  def test_search_rank_orders_results_via_solr_side_boost
+    with_ranked_melanoma_ontologies([
+      ["RANKHIGH", 1.0, "./test/data/ontology_files/search_rank_melanoma_upper.owl"],
+      ["RANKMIDHI", 0.7, "./test/data/ontology_files/search_rank_melanoma_lower.owl"],
+      ["RANKMIDLO", 0.4, "./test/data/ontology_files/search_rank_melanoma_lower.owl"],
+      ["RANKLOW", 0.1, "./test/data/ontology_files/search_rank_melanoma_lower.owl"]
+    ]) do
       get "/search?q=melanoma&pagesize=3"
       assert last_response.ok?, "expected 200, got #{last_response.status}: #{last_response.body[0, 200]}"
       results = MultiJson.load(last_response.body)
       acronyms = results["collection"].map { |doc| doc["links"]["ontology"].split("/")[-1] }
 
-      assert_operator results["totalCount"], :>, 3
-      assert_equal 3, results["collection"].length
-      assert_equal %w[RANKHIGH RANKMIDHI RANKMIDLO], acronyms
-    ensure
-      rank_redis.del(LinkedData::Models::Ontology::ONTOLOGY_RANK_REDIS_FIELD)
-      ranked_ontologies.map(&:first).each do |acronym|
-        ont = LinkedData::Models::Ontology.find(acronym).first
-        ont.delete if ont
-      end
+      assert_operator results["totalCount"], :>=, 4,
+                      "all four seeded ontologies must match q=melanoma (totalCount counts pre-pagination)"
+      assert_equal 3, results["collection"].length,
+                   "pagesize=3 must return exactly 3 docs on page 1"
+      assert_equal %w[RANKHIGH RANKMIDHI RANKMIDLO], acronyms,
+                   "Solr-side boost must order page 1 by descending ontologyRank"
+      refute_includes acronyms, "RANKLOW",
+                      "the lowest-ranked ontology must be excluded from page 1 even though it matches the query"
     end
   end
 
@@ -573,5 +575,55 @@ class TestSearchController < TestCase
     refute_nil res["collection"].select{|doc| doc["@id"].eql?('http://bioontology.org/ontologies/Activity.owl#Activity')}.first
   end
 
+  private
+
+  # Helper for ranking-quality tests: seed BioPortal ontology rank into Redis
+  # for the given ontologies, index them into the term_search Solr collection,
+  # yield to the block to run assertions, then clean up Redis and ontologies.
+  #
+  # Each entry is [acronym, bioportal_score, owl_file_path].
+  def with_ranked_melanoma_ontologies(ranked_ontologies)
+    ranking = ranked_ontologies.to_h do |acronym, bioportal_score, _|
+      [acronym, { bioportalScore: bioportal_score, umlsScore: 0.0 }]
+    end
+    rank_redis = Redis.new(host: LinkedData.settings.ontology_analytics_redis_host,
+                           port: LinkedData.settings.ontology_analytics_redis_port,
+                           timeout: 30)
+
+    begin
+      rank_redis.set(LinkedData::Models::Ontology::ONTOLOGY_RANK_REDIS_FIELD, Marshal.dump(ranking))
+
+      process_options = {
+        process_rdf: true,
+        extract_metadata: false,
+        generate_missing_labels: false,
+        run_metrics: false,
+        reasoning: false,
+        index_search: true,
+        index_properties: false
+      }
+
+      ranked_ontologies.each do |acronym, _, file_path|
+        LinkedData::SampleData::Ontology.create_ontologies_and_submissions({
+          process_submission: true,
+          process_options: process_options,
+          acronym: acronym,
+          acronym_suffix: "",
+          name: "#{acronym} Search Test",
+          file_path: file_path,
+          ont_count: 1,
+          submission_count: 1
+        })
+      end
+
+      yield
+    ensure
+      rank_redis.del(LinkedData::Models::Ontology::ONTOLOGY_RANK_REDIS_FIELD)
+      ranked_ontologies.map(&:first).each do |acronym|
+        ont = LinkedData::Models::Ontology.find(acronym).first
+        ont.delete if ont
+      end
+    end
+  end
 
 end

--- a/test/controllers/test_search_controller.rb
+++ b/test/controllers/test_search_controller.rb
@@ -101,6 +101,80 @@ class TestSearchController < TestCase
     end
   end
 
+  def test_search_rank_uses_case_insensitive_exact_match_before_page_sorting
+    ranked_ontologies = [
+      ["RANKHIGH", 1.0, "./test/data/ontology_files/search_rank_melanoma_upper.owl"],
+      ["RANKMIDHI", 0.7, "./test/data/ontology_files/search_rank_melanoma_lower.owl"],
+      ["RANKMIDLO", 0.4, "./test/data/ontology_files/search_rank_melanoma_lower.owl"],
+      ["RANKLOW", 0.1, "./test/data/ontology_files/search_rank_melanoma_lower.owl"]
+    ]
+    ranking = ranked_ontologies.to_h do |acronym, bioportal_score, _|
+      [acronym, { bioportalScore: bioportal_score, umlsScore: 0.0 }]
+    end
+    rank_redis = Redis.new(host: LinkedData.settings.ontology_analytics_redis_host,
+                           port: LinkedData.settings.ontology_analytics_redis_port,
+                           timeout: 30)
+
+    begin
+      rank_redis.set(LinkedData::Models::Ontology::ONTOLOGY_RANK_REDIS_FIELD, Marshal.dump(ranking))
+
+      rank_search_process_options = {
+        process_rdf: true,
+        extract_metadata: false,
+        generate_missing_labels: false,
+        run_metrics: false,
+        reasoning: false,
+        index_search: true,
+        index_properties: false
+      }
+
+      ranked_ontologies.each do |acronym, _, file_path|
+        LinkedData::SampleData::Ontology.create_ontologies_and_submissions({
+          process_submission: true,
+          process_options: rank_search_process_options,
+          acronym: acronym,
+          acronym_suffix: "",
+          name: "#{acronym} Search Test",
+          file_path: file_path,
+          ont_count: 1,
+          submission_count: 1
+        })
+      end
+
+      schema = Goo.search_client(:term_search).fetch_schema
+      pref_label_exact = schema["fields"].find { |field| field["name"] == "prefLabelExact" }
+      synonym_exact = schema["fields"].find { |field| field["name"] == "synonymExact" }
+
+      assert_equal "string_ci", pref_label_exact["type"]
+      assert_equal "string_ci", synonym_exact["type"]
+
+      exact_match_resp = LinkedData::Models::Class.search(
+        'prefLabelExact:"melanoma"',
+        {
+          fq: "submissionAcronym:RANKHIGH AND obsolete:false AND -provisional:true",
+          fl: "submissionAcronym,prefLabel,score",
+          rows: 10
+        }
+      )
+      assert_equal 1, exact_match_resp["response"]["numFound"]
+
+      get "/search?q=melanoma&pagesize=3"
+      assert last_response.ok?, "expected 200, got #{last_response.status}: #{last_response.body[0, 200]}"
+      results = MultiJson.load(last_response.body)
+      acronyms = results["collection"].map { |doc| doc["links"]["ontology"].split("/")[-1] }
+
+      assert_operator results["totalCount"], :>, 3
+      assert_equal 3, results["collection"].length
+      assert_equal %w[RANKHIGH RANKMIDHI RANKMIDLO], acronyms
+    ensure
+      rank_redis.del(LinkedData::Models::Ontology::ONTOLOGY_RANK_REDIS_FIELD)
+      ranked_ontologies.map(&:first).each do |acronym|
+        ont = LinkedData::Models::Ontology.find(acronym).first
+        ont.delete if ont
+      end
+    end
+  end
+
   # Regression: when the acronyms list filters down to empty (here via an
   # ontology_types filter that matches no seeded ontology), the Solr fq used
   # to start with " AND obsolete:false ..." — a malformed query rejected by

--- a/test/data/ontology_files/search_rank_melanoma_lower.owl
+++ b/test/data/ontology_files/search_rank_melanoma_lower.owl
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+  <owl:Ontology rdf:about="http://example.org/search-rank-lower"/>
+
+  <owl:Class rdf:about="http://example.org/search-rank-lower#melanoma">
+    <skos:prefLabel>melanoma</skos:prefLabel>
+  </owl:Class>
+</rdf:RDF>

--- a/test/data/ontology_files/search_rank_melanoma_upper.owl
+++ b/test/data/ontology_files/search_rank_melanoma_upper.owl
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+  <owl:Ontology rdf:about="http://example.org/search-rank-upper"/>
+
+  <owl:Class rdf:about="http://example.org/search-rank-upper#Melanoma">
+    <skos:prefLabel>Melanoma</skos:prefLabel>
+  </owl:Class>
+</rdf:RDF>


### PR DESCRIPTION
## Summary

Moves BioPortal ontology rank into Solr's edismax scoring so it participates BEFORE pagination, fixing #230. With the previous post-hoc Ruby sort, high-rank ontologies stranded beyond Solr's first-page window couldn't be promoted; now they're ranked at the Solr layer and arrive on page 1 by score.

The change is small and surgical — single `boost` parameter + removal of the now-redundant Ruby tiebreaker and its dead support code.

## Addresses
- https://github.com/ncbo/ontologies_api/issues/230

## Dependencies

This PR depends on companion PRs in three other repos. All must merge together as a coordinated cutover.

- [ ] **ncbo/goo#187** — alias-guard fix in `SolrConnector#init` that prevents `CREATEALIAS` from silently shadowing an existing collection (discovered and fixed during this PR's testing); also bundles unrelated `commitWithin` support.
- [ ] **ncbo/ontologies_linked_data#294** — schema (`string_ci` exact fields, `ontologyRank` field), indexer population, plus paired term-indexing improvements.
- [ ] **ncbo/ncbo_cron#131** — bulk-indexer improvements (consumes `commitWithin`, skips CSV / `unindex_by_acronym` / forced optimize when appropriate) needed to rebuild the term-search collection efficiently under the new schema before this PR can deploy.

## Deploy coordination

This change requires the active Solr `term_search` alias to point to a collection that defines the `ontologyRank` field. Deploying against the old `term_search_core1` schema returns `HTTP 400 "undefined field: ontologyRank"`. The cutover is a single coordinated event:

1. The new collection (`term_search_20260431` at time of writing) completes its full reindex.
2. The `term_search` alias is flipped from `term_search_core1` to the new collection.
3. This PR + the three companion PRs all deploy together.

## Commits

| SHA | Change |
|---|---|
| 2a5c809 | Add `boost=sum(ontologyRank,1)` to all three edismax paths; bump `goo`/`ncbo_cron`/`ontologies_linked_data` to the matching branch tips |
| 59ad6e8 | Remove the post-hoc Ruby `docs.sort!` block |
| f02884d | Remove the now-unused `ontology_rank` attachment, `Ontology.rank` fetch, and skip-list entry |
| 3de4ed2 | Bump goo pin to the alias-guard fix (684fbe06) |
| 65aa4a7 | Add ranking regression test + OWL fixtures |
| 61a1a59 | Split the test into schema-only and boost-only concerns for diagnostic clarity |

## Test plan

Two new tests are added by this PR; both pass:

- `test_schema_uses_case_insensitive_string_ci_exact_fields` — asserts the Phase 1 schema invariant (case-insensitive exact match via `string_ci`).
- `test_search_rank_orders_results_via_solr_side_boost` — asserts the Phase 2 mechanism (pagesize=3 returns the top 3 ontologies by rank, with the lowest-ranked correctly excluded from page 1 but still counted in `totalCount`).

Empirical validation against the live `term_search_20260431` collection on staging:

| Query | Result |
|---|---|
| `q=melanoma` | Top 5: HRDO, MESH (rank 1.000), MEDDRA (0.959), LOINC (0.947), NIFSTD. Phase 0 predicted exactly this. |
| `q=diabetes` | Top 5: RADLEX, MEDDRA, LOINC×3. High-rank ontologies elevated as expected. |
| `q=DOID:1909` | Previously-tied score-611 cluster now rank-ordered (NIFSTD, DDSS, ERO, CLO, ...). OBO ID work (#134/#135) preserved. |
| `q=C0025202` | OCHV at #1 by notation match; cross-references from MESH/MEDDRA via `cui` field appear afterward, rank-ordered. |
| `q=melanoma&ontologies=DDSS` | All results scoped to DDSS as expected. |

## What does NOT change

- `qf` field weights — preserves the OBO ID search enhancement from #134/#135.
- `bq=idAcronymMatch:true^80` — preserved.
- `properties_search_helper.rb` — different model, different semantics. Parallel pattern documented as follow-up: **#231**.
- Schema or index — Phase 1 already shipped those on the OLD branch.

## Out of scope (deferred)

- Property-search ranking has the same architectural anti-pattern and a verifiable bug — see #231.
- Cross-Solr-page rank-ordering regression test — the new tests use 4 small fixtures which don't force Solr-side pagination; reproducing the original #230 failure mode would need 50+ matching docs across ontologies. Worth a separate, heavier regression-test PR.
- Multilingual prefLabel de-duplication (visible in some `q=diabetes` results as repeated LOINC entries) — separate, pre-existing concern surfaced but not introduced by this change.
- Properties helper retuning, `qf` weight changes, autocomplete redesign — all deferred.

## Operational note

During testing of this PR we triggered a goo-side bug that shadowed the in-progress `term_search_20260431` collection with an alias (see ncbo/goo#187). The collection's data on disk was recoverable by deleting the rogue alias; ~24 ontologies whose writes were diverted to `term_search_bootstrap` during the incident window will need re-indexing into `term_search_20260431` after the main reindex completes.