### PR TITLE
Fix: malformed Solr query in Annotator (#233)

### DIFF
--- a/helpers/search_helper.rb
+++ b/helpers/search_helper.rb
@@ -421,6 +421,8 @@ module Sinatra
       # Populate an array of classes. Returns a hash where the key is ontology_uri + class_id:
       # "http://data.bioontology.org/ontologies/ONThttp://ont.org/class1" => cls
       def populate_classes_from_search(classes, ontology_acronyms=nil)
+        return {} if classes.nil? || classes.empty?
+
         class_ids = []
         acronyms = (ontology_acronyms.nil?) ? [] : ontology_acronyms
         classes.each {|c| class_ids << c.id.to_s; acronyms << c.submission.ontology.acronym.to_s unless ontology_acronyms}

--- a/test/helpers/test_search_helper.rb
+++ b/test/helpers/test_search_helper.rb
@@ -126,4 +126,20 @@ class TestSearchHelper < TestCaseHelpers
                       "fq must include each class id in the terms-parser values"
     end
   end
+
+  def test_populate_classes_from_search_returns_empty_hash_without_query_for_empty_classes
+    h = helper
+
+    klass = LinkedData::Models::Class
+    original_search = klass.method(:submit_search_query)
+    klass.define_singleton_method(:submit_search_query) do |_query, _params|
+      flunk "empty class population should not submit a Solr query"
+    end
+
+    begin
+      assert_equal({}, h.populate_classes_from_search([], ["TEST"]))
+    ensure
+      klass.define_singleton_method(:submit_search_query, original_search)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes https://github.com/ncbo/ontologies_api/issues/233.

`GET /annotator` returned 500 when filters reduced the annotation set to zero and `include` was present. The empty annotation set still flowed into `populate_classes_from_search`, which built a Solr filter ending in a bare `AND`, causing Solr to return 400.

This change makes `populate_classes_from_search` return an empty hash immediately when there are no classes to populate.

## Verification

- Reproduced the original request returning 500 before the fix:
  `/annotator?text=Melanoma+is+a+malignant+tumor+of+melanocytes...&include=prefLabel&semantic_types=T052`
- Confirmed the same request now returns `200` with body `[]`.
- Ran `test/helpers/test_search_helper.rb`.