### PR TITLE
Fix: restore production access log output

### DIFF
--- a/config/logging.rb
+++ b/config/logging.rb
@@ -1,9 +1,24 @@
 require 'logger'
+require 'rack/common_logger'
 
-configure do
-  log_file = File.new("log/#{settings.environment}.log", 'a+')
-  log_file.sync = true
-  LOGGER = Logger.new(log_file)
-  LOGGER.level = settings.development? ? Logger::DEBUG : Logger::INFO
-  set :logger, LOGGER
+class CustomLogger < Logger
+  alias write <<
+
+  def flush
+    ((instance_variable_get :@logdev).instance_variable_get :@dev).flush
+  end
 end
+
+if [:development, :console].include?(settings.environment)
+  LOGGER = CustomLogger.new(STDOUT)
+  LOGGER.level = Logger::DEBUG
+else
+  Dir.mkdir('log') unless File.exist?('log')
+  log = File.new("log/#{settings.environment}.log", 'a+')
+  log.sync = true
+  LOGGER = CustomLogger.new(log)
+  LOGGER.level = Logger::INFO
+  use Rack::CommonLogger, log
+end
+
+set :logger, LOGGER

--- a/test/controllers/test_home_controller.rb
+++ b/test/controllers/test_home_controller.rb
@@ -1,6 +1,22 @@
 require_relative '../test_case'
 
 class TestHomeController < TestCase
+  # Regression: ncbo/bioportal-internal-tracker#18
+  def test_requests_are_written_to_common_access_log
+    log_path = File.expand_path('../../log/test.log', __dir__)
+    File.truncate(log_path, 0) if File.exist?(log_path)
+
+    get '/documentation'
+    assert last_response.ok?, get_errors(last_response)
+
+    access_log = File.read(log_path)
+    common_log_line = %r{\S+ - \S+ \[\d{2}/[A-Z][a-z]{2}/\d{4}:\d{2}:\d{2}:\d{2} [+-]\d{4}\] "GET /documentation HTTP/1\.[01]" 200 \S+ \d+\.\d{4}}
+    assert_match(
+      common_log_line,
+      access_log
+    )
+  end
+
   def test_home_index_returns_links_hash
     get '/'
     assert last_response.ok?, get_errors(last_response)


### PR DESCRIPTION
## Summary

Restores the pre-Sinatra/Rack upgrade access logging behavior so `production.log` once again contains Rack common-format HTTP access log lines used by API access log analytics.

This fixes ncbo/bioportal-internal-tracker#18, where `production.log` stopped containing request lines like:

```text
172.20.222.51 - ncbobioportal [20/Apr/2026:00:00:27 -0700] "GET /ontologies/... HTTP/1.0" 200 4134 2.2539
```

and instead only contained Ruby logger application messages.

## Changes

- Restores `CustomLogger` and the historical environment split:
  - `development` / `console` log to STDOUT
  - other environments log to `log/<environment>.log`
- Restores `Rack::CommonLogger` for non-development environments, writing common-format HTTP access lines to the environment log file.
- Keeps the current `set :logger, LOGGER` wiring for Sinatra compatibility.
- Adds a regression test that verifies a real Rack request writes a common-format access log line to `log/test.log`.

## Verification

```sh
bundle exec ruby test/controllers/test_home_controller.rb --name test_requests_are_written_to_common_access_log
bundle exec ruby test/controllers/test_home_controller.rb
git diff --check
```