### PR TITLE
Perf: batch /metrics/missing queries

### DIFF
--- a/controllers/metrics_controller.rb
+++ b/controllers/metrics_controller.rb
@@ -31,29 +31,41 @@ class MetricsController < ApplicationController
     #    "UPLOADED"]
 
     get '/missing' do
-      missing = Set.new()
-      onts = LinkedData::Models::Ontology.all
-      onts.each do |ont|
-        ont.bring(:summaryOnly)
+      onts = LinkedData::Models::Ontology.where
+                                          .include(:acronym, :summaryOnly,
+                                                   submissions: [:submissionId, :submissionStatus])
+                                          .all
+      ontology_submissions = onts.filter_map do |ont|
         next if ont.summaryOnly
-        # Get the latest submission, but ensure the processing status
-        # doesn't require anything more than RDF parsing.
-        sub = ont.latest_submission(:status => 'RDF')
+
+        sub = ont.submissions
+                 .select { |submission| submission.ready?(status: 'RDF') }
+                 .max_by { |submission| submission.submissionId.to_i }
+        [ont, sub]
+      end
+
+      submissions_with_metrics = ontology_submissions.filter_map do |_ont, sub|
+        next if sub.nil?
+
+        status = sub.submissionStatus.map { |s| s.id.to_s.split('/').last }
+        sub if status.include?('METRICS') && !status.include?('ERROR_METRICS')
+      end
+
+      unless submissions_with_metrics.empty?
+        LinkedData::Models::OntologySubmission.where.models(submissions_with_metrics)
+                                               .include(:metrics).all
+      end
+
+      missing = ontology_submissions.each_with_object(Set.new) do |(ont, sub), result|
         if sub.nil?
-          missing.add(ont)
-        else
-          status = sub.submissionStatus.map {|s| s.id.to_s.split('/').last }
-          if status.include? 'ERROR_METRICS'
-            missing.add(ont)
-          else
-            if status.include? 'METRICS'
-              sub.bring(:metrics)
-              missing.add(ont) if sub.metrics.nil?
-            else
-              missing.add(ont)
-            end
-          end
+          result.add(ont)
+          next
         end
+
+        status = sub.submissionStatus.map { |s| s.id.to_s.split('/').last }
+        result.add(ont) if status.include?('ERROR_METRICS') ||
+                           !status.include?('METRICS') ||
+                           sub.metrics.nil?
       end
       reply missing.to_a
     end

--- a/script/benchmark_metrics_missing_latency.rb
+++ b/script/benchmark_metrics_missing_latency.rb
@@ -1,0 +1,136 @@
+require 'digest'
+require 'json'
+require 'net/http'
+require 'time'
+require 'uri'
+
+before_url = URI(ENV.fetch('BEFORE_URL', 'http://localhost:9393/metrics/missing'))
+after_url = URI(ENV.fetch('AFTER_URL', 'http://localhost:9394/metrics/missing'))
+warmups = Integer(ENV.fetch('WARMUPS', 5))
+samples = Integer(ENV.fetch('SAMPLES', 30))
+read_timeout = Integer(ENV.fetch('READ_TIMEOUT', 300))
+
+raise 'WARMUPS must not be negative' if warmups.negative?
+raise 'SAMPLES must be positive' unless samples.positive?
+raise 'READ_TIMEOUT must be positive' unless read_timeout.positive?
+
+def canonicalize(value)
+  case value
+  when Array
+    value.map { |item| canonicalize(item) }
+  when Hash
+    value.keys.sort.to_h { |key| [key, canonicalize(value.fetch(key))] }
+  else
+    value
+  end
+end
+
+def canonical_response(response)
+  canonical = canonicalize(response)
+  return canonical unless canonical.is_a?(Array)
+
+  canonical.sort_by do |item|
+    item.is_a?(Hash) ? item.fetch('acronym', JSON.generate(item)) : JSON.generate(item)
+  end
+end
+
+def fetch(url, read_timeout:, label:)
+  warn "#{Time.now.utc.iso8601} start #{label}"
+  request = Net::HTTP::Get.new(url)
+  started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  response = Net::HTTP.start(url.host, url.port, open_timeout: 10, read_timeout: read_timeout) do |http|
+    http.request(request)
+  end
+  elapsed_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1_000
+  raise "#{url} returned HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+  warn "#{Time.now.utc.iso8601} finish #{label}: #{elapsed_ms.round(1)} ms"
+  [elapsed_ms, canonical_response(JSON.parse(response.body))]
+end
+
+def percentile(values, percentile)
+  sorted = values.sort
+  index = [(sorted.length * percentile).ceil - 1, 0].max
+  sorted.fetch(index)
+end
+
+def median(values)
+  sorted = values.sort
+  midpoint = sorted.length / 2
+  return sorted.fetch(midpoint) if sorted.length.odd?
+
+  (sorted.fetch(midpoint - 1) + sorted.fetch(midpoint)) / 2
+end
+
+def summarize(values)
+  {
+    median_ms: median(values).round(1),
+    p95_ms: percentile(values, 0.95).round(1),
+    mean_ms: (values.sum / values.length).round(1)
+  }
+end
+
+def percent_delta(before, after)
+  (((after - before) / before) * 100).round(1)
+end
+
+expected_response = nil
+warmups.times do |index|
+  _before_ms, before_response = fetch(before_url, read_timeout: read_timeout,
+                                                  label: "warmup #{index + 1}/#{warmups} before")
+  _after_ms, after_response = fetch(after_url, read_timeout: read_timeout,
+                                               label: "warmup #{index + 1}/#{warmups} after")
+  raise 'Before and after warmup responses differ.' unless before_response == after_response
+  raise 'The response changed during warmup.' if expected_response && expected_response != before_response
+
+  expected_response ||= before_response
+end
+
+timings = { before: [], after: [] }
+samples.times do |index|
+  before_ms, before_response = fetch(before_url, read_timeout: read_timeout,
+                                                 label: "sample #{index + 1}/#{samples} before")
+  after_ms, after_response = fetch(after_url, read_timeout: read_timeout,
+                                              label: "sample #{index + 1}/#{samples} after")
+  raise 'Before and after measured responses differ.' unless before_response == after_response
+  raise 'The response changed during measurement.' if expected_response && expected_response != before_response
+
+  expected_response ||= before_response
+  timings.fetch(:before) << before_ms
+  timings.fetch(:after) << after_ms
+end
+
+before_summary = summarize(timings.fetch(:before))
+after_summary = summarize(timings.fetch(:after))
+canonical_json = JSON.generate(expected_response)
+
+result = {
+  compared: {
+    before: before_url.to_s,
+    after: after_url.to_s
+  },
+  method: {
+    warmups_per_revision: warmups,
+    measured_requests_per_revision: samples,
+    measured_order: 'alternating before, after',
+    read_timeout_seconds: read_timeout
+  },
+  response: {
+    entries: expected_response.length,
+    canonical_sha256: Digest::SHA256.hexdigest(canonical_json),
+    canonical_bytes: canonical_json.bytesize
+  },
+  latency: {
+    before: before_summary,
+    after: after_summary,
+    percent_delta: before_summary.to_h do |metric, before_value|
+      [metric, percent_delta(before_value, after_summary.fetch(metric))]
+    end
+  },
+  samples_ms: {
+    before: timings.fetch(:before).map { |value| value.round(1) },
+    after: timings.fetch(:after).map { |value| value.round(1) }
+  }
+}
+
+puts JSON.pretty_generate(result)

--- a/script/benchmark_metrics_missing_queries.rb
+++ b/script/benchmark_metrics_missing_queries.rb
@@ -1,0 +1,73 @@
+require_relative '../test/test_case'
+
+module MetricsMissingQueryCounter
+  def query(*args, **kwargs, &block)
+    count = Thread.current[:metrics_missing_query_count]
+    Thread.current[:metrics_missing_query_count] = count + 1 unless count.nil?
+    super
+  end
+end
+
+unless Goo::SPARQL::Client.ancestors.include?(MetricsMissingQueryCounter)
+  Goo::SPARQL::Client.prepend(MetricsMissingQueryCounter)
+end
+
+class BenchmarkMetricsMissingQueries < TestCase
+  PROCESSED_OPTIONS = {
+    ont_count: 2,
+    submission_count: 3,
+    submissions_to_process: [1, 2],
+    process_submission: true,
+    process_options: {
+      process_rdf: true,
+      extract_metadata: false,
+      run_metrics: true,
+      index_properties: true
+    },
+    random_submission_count: false
+  }.freeze
+
+  NO_RDF_OPTIONS = {
+    ont_count: 2,
+    submission_count: 1,
+    process_submission: false,
+    random_submission_count: false
+  }.freeze
+
+  def before_suite
+    raise 'Refusing to replace a non-test dataset' if OntologySubmission.all.count > 100
+
+    delete_ontologies_and_submissions
+    create_ontologies_and_submissions(PROCESSED_OPTIONS)
+  end
+
+  def test_query_counts
+    processed = measure_request
+    assert_equal([], processed.fetch(:acronyms))
+
+    delete_ontologies_and_submissions
+    create_ontologies_and_submissions(NO_RDF_OPTIONS)
+
+    no_rdf = measure_request
+    assert_equal(%w[TEST-ONT-0 TEST-ONT-1], no_rdf.fetch(:acronyms))
+
+    puts "METRICS_MISSING_BENCHMARK=#{JSON.generate(processed: processed, no_rdf: no_rdf)}"
+  end
+
+  private
+
+  def measure_request
+    Thread.current[:metrics_missing_query_count] = 0
+    get '/metrics/missing'
+    query_count = Thread.current[:metrics_missing_query_count]
+
+    assert last_response.ok?
+    response = MultiJson.load(last_response.body)
+    {
+      queries: query_count,
+      acronyms: response.map { |ontology| ontology.fetch('acronym') }.sort
+    }
+  ensure
+    Thread.current[:metrics_missing_query_count] = nil
+  end
+end

--- a/test/controllers/test_metrics_controller.rb
+++ b/test/controllers/test_metrics_controller.rb
@@ -1,6 +1,26 @@
 require_relative '../test_case'
 
+module MetricsGooQueryCountSpy
+  def query(*args, **kwargs, &block)
+    count = Thread.current[:metrics_goo_query_count]
+    Thread.current[:metrics_goo_query_count] = count + 1 unless count.nil?
+    super
+  end
+end
+
+unless Goo::SPARQL::Client.ancestors.include?(MetricsGooQueryCountSpy)
+  Goo::SPARQL::Client.prepend(MetricsGooQueryCountSpy)
+end
+
 class TestMetricsController < TestCase
+
+  def count_sparql_queries
+    Thread.current[:metrics_goo_query_count] = 0
+    yield
+    Thread.current[:metrics_goo_query_count]
+  ensure
+    Thread.current[:metrics_goo_query_count] = nil
+  end
 
   def before_suite
     if OntologySubmission.all.count > 100
@@ -76,12 +96,12 @@ class TestMetricsController < TestCase
   end
 
   def test_metrics_missing
-    skip "Test takes 160+ seconds to run, disable until we investigate"
     # test for zero ontologies without metrics (created by before_suite)
-    get '/metrics/missing'
+    query_count = count_sparql_queries { get '/metrics/missing' }
     assert last_response.ok?
     ontologies = MultiJson.load(last_response.body)
     assert_equal(0, ontologies.length, msg = 'Failure to detect 0 ontologies with missing metrics.')
+    assert_equal(2, query_count, 'Expected missing metrics lookup to use two batched SPARQL queries.')
     # create ontologies with latest submissions that have no metrics
     delete_ontologies_and_submissions
     options = { ont_count: 2,
@@ -89,10 +109,12 @@ class TestMetricsController < TestCase
                 process_submission: false,
                 random_submission_count: false }
     create_ontologies_and_submissions(options)
-    get '/metrics/missing'
+    query_count = count_sparql_queries { get '/metrics/missing' }
     assert last_response.ok?
     ontologies = MultiJson.load(last_response.body)
     assert_equal(2, ontologies.length, msg = 'Failure to detect 2 ontologies with missing metrics.')
+    assert_equal(%w[TEST-ONT-0 TEST-ONT-1], ontologies.map { |ontology| ontology['acronym'] }.sort)
+    assert_equal(2, query_count, 'Expected missing metrics lookup to use two batched SPARQL queries.')
     # recreate the before_suite data (this test might not be the last one to run in the suite)
     delete_ontologies_and_submissions
     create_ontologies_and_submissions(@@options)


### PR DESCRIPTION
## Summary
- batch-load ontology acronyms, `summaryOnly`, submissions, and submission statuses
- select the latest RDF-ready submission in memory
- batch-load metrics only for submissions whose statuses require the metrics check
- restore the skipped regression test and assert a constant two SPARQL queries
- add reproducible query-count and latency benchmark harnesses

Implements #240

## Verification
- focused `test_metrics_missing`: passed
- `test/controllers/test_metrics_controller.rb`: 5 tests, 59 assertions, 0 failures, 0 errors
- full suite: 290 tests, 12,394 assertions; an unrelated New Relic/net-http segmentation fault killed the RackAttack test server, and the RackAttack file passed standalone (6 tests, 28 assertions)

## Performance

**Environment:** Work metrics used the local 4store test backend at `localhost:9000`. Latency used two local API processes against the same staging data services, with the merge-base on `localhost:9393` and this branch on `localhost:9394`.
**Compared:** [`39d00c292753be237e379666740683103cdb0674`](https://github.com/ncbo/ontologies_api/commit/39d00c292753be237e379666740683103cdb0674) (merge-base with [`origin/develop`](https://github.com/ncbo/ontologies_api/tree/develop)) vs [`854f78ab0e96a9d775ae6618b27c0021c6d12a60`](https://github.com/ncbo/ontologies_api/commit/854f78ab0e96a9d775ae6618b27c0021c6d12a60).
**Method:** Query counts used one request for each deterministic fixture at each revision. Latency used 5 warmups plus 30 measured requests per revision in alternating before/after order. Inputs were identical. Every warmup and measured response contained the same 109 ontology objects and field values after canonicalizing the endpoint's unordered top-level collection (SHA-256 `440b6ef44c57f59c67e42abb99a5392d3e88ad3f02f1a8a7a0c43d5329b1beef`, 307,837 bytes); raw collection order differed.

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| SPARQL queries, processed fixture | 3 | 2 | -1 (-33.3%) |
| SPARQL queries, no-RDF fixture | 9 | 2 | -7 (-77.8%) |
| Median latency | 176,176.4 ms | 9,252.7 ms | -94.7% |
| p95 latency | 187,192.4 ms | 9,931.8 ms | -94.7% |
| Mean latency | 174,280.3 ms | 9,284.1 ms | -94.7% |

On this staging snapshot, the change held query work to two SPARQL requests for both measured fixture shapes and reduced end-to-end latency by about 94.7%. The query measurements are not extrapolated to larger ontology counts.

Reproduce work metrics with [`script/benchmark_metrics_missing_queries.rb`](https://github.com/ncbo/ontologies_api/blob/perf/metrics-missing-batching/script/benchmark_metrics_missing_queries.rb), copied unchanged into each revision's worktree:

```bash
GOO_BACKEND_NAME=4store GOO_PORT=9000 GOO_PATH_QUERY=/sparql/ GOO_PATH_DATA=/data/ GOO_PATH_UPDATE=/update/ MGREP_PORT=55556 \
  rbenv exec bundle exec ruby script/benchmark_metrics_missing_queries.rb
```

Reproduce latency with [`script/benchmark_metrics_missing_latency.rb`](https://github.com/ncbo/ontologies_api/blob/perf/metrics-missing-batching/script/benchmark_metrics_missing_latency.rb) after starting the merge-base and changed API processes:

```bash
WARMUPS=5 SAMPLES=30 READ_TIMEOUT=600 \
  BEFORE_URL=http://localhost:9393/metrics/missing \
  AFTER_URL=http://localhost:9394/metrics/missing \
  rbenv exec ruby script/benchmark_metrics_missing_latency.rb
```
