### PR TITLE
Perf: instrument /search request path with New Relic method tracers

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -183,6 +183,9 @@ require 'newrelic_rpm'
 # Initialize the app
 require_relative 'init'
 
+# Custom method tracers (must load after init so traced methods exist)
+require_relative 'config/newrelic_method_tracers'
+
 # Enter console mode
 if settings.environment == :console
   require 'rack/test'

--- a/config/newrelic_method_tracers.rb
+++ b/config/newrelic_method_tracers.rb
@@ -8,6 +8,12 @@
 #
 # Must be loaded after init.rb so all traced methods are already defined.
 # When the agent is disabled (development/test), the tracers are no-ops.
+#
+# Kill switch: set NEWRELIC_CUSTOM_TRACERS=off (and restart) to skip
+# registration entirely, e.g. to rule instrumentation out while
+# debugging. Requires a process restart to take effect either way.
+return if ENV['NEWRELIC_CUSTOM_TRACERS'] == 'off'
+
 require 'new_relic/agent/method_tracer'
 
 module Sinatra

--- a/config/newrelic_method_tracers.rb
+++ b/config/newrelic_method_tracers.rb
@@ -1,10 +1,14 @@
-# Custom New Relic method tracers for the /search request path.
+# Custom New Relic method tracers for hot request paths.
 #
-# The GET /search transaction spends >90% of its time in application code
-# that the agent reports as a single opaque "Sinatra::Application#GET
-# (unknown)" segment (~830 ms of the ~890 ms average). These tracers split
-# that block into named Custom/* child segments so transaction traces and
-# the breakdown table show where the time actually goes.
+# High-traffic transactions (GET /search, GET .../classes/{cls}/tree)
+# spend most of their time in application code that the agent reports as
+# a single opaque "Sinatra::Application#GET (unknown)" segment. These
+# tracers split that block into named Custom/* child segments so
+# transaction traces and the breakdown table show where the time goes.
+#
+# To instrument another endpoint, add its module/class and methods to the
+# registry below; test/helpers/test_newrelic_method_tracers.rb consumes
+# the same registry, so new entries are covered automatically.
 #
 # Must be loaded after init.rb so all traced methods are already defined.
 # When the agent is disabled (development/test), the tracers are no-ops.
@@ -12,44 +16,50 @@
 # Kill switch: set NEWRELIC_CUSTOM_TRACERS=off (and restart) to skip
 # registration entirely, e.g. to rule instrumentation out while
 # debugging. Requires a process restart to take effect either way.
-return if ENV['NEWRELIC_CUSTOM_TRACERS'] == 'off'
+module NewRelicMethodTracers
+  # Instance methods, keyed by module/class name. Methods inherited from
+  # concerns or mixins (e.g. the tree methods, defined in an
+  # ontologies_linked_data concern) can be traced here without touching
+  # the defining repo.
+  INSTANCE_METHODS = {
+    # GET /search pipeline
+    'Sinatra::Helpers::SearchHelper' => %i[process_search get_term_search_query
+                                           add_matched_fields filter_attrs_by_language],
+    # App-wide: ontology access list load + response serialization entry
+    'Sinatra::Helpers::ApplicationHelper' => %i[restricted_ontologies reply],
+    # GET /ontologies/{ontology}/classes/{cls}/tree pipeline
+    'LinkedData::Models::Class' => %i[tree tree_sorted paths_to_root]
+  }.freeze
 
-require 'new_relic/agent/method_tracer'
+  # Class (singleton) methods, keyed by class name.
+  CLASS_METHODS = {
+    # Hypermedia links + JSON generation for every API response
+    'LinkedData::Serializer' => %i[build_response serialize],
+    # Solr query execution incl. Ruby-side response parsing (the HTTP
+    # call itself already appears as an External segment)
+    'LinkedData::Models::Class' => %i[search]
+  }.freeze
 
-module Sinatra
-  module Helpers
-    module SearchHelper
-      include ::NewRelic::Agent::MethodTracer
-
-      add_method_tracer :process_search, 'Custom/SearchHelper/process_search'
-      add_method_tracer :get_term_search_query, 'Custom/SearchHelper/get_term_search_query'
-      add_method_tracer :add_matched_fields, 'Custom/SearchHelper/add_matched_fields'
-      # Called once per returned document (default pagesize 50).
-      add_method_tracer :filter_attrs_by_language, 'Custom/SearchHelper/filter_attrs_by_language'
+  def self.register
+    INSTANCE_METHODS.each do |const_name, methods|
+      install(Object.const_get(const_name), const_name, methods)
     end
 
-    module ApplicationHelper
-      include ::NewRelic::Agent::MethodTracer
+    CLASS_METHODS.each do |const_name, methods|
+      install(Object.const_get(const_name).singleton_class, const_name, methods)
+    end
+  end
 
-      # Site-wide searches load every ontology here before querying Solr.
-      add_method_tracer :restricted_ontologies, 'Custom/ApplicationHelper/restricted_ontologies'
-      add_method_tracer :reply, 'Custom/ApplicationHelper/reply'
+  def self.install(target, const_name, methods)
+    target.include(::NewRelic::Agent::MethodTracer)
+
+    methods.each do |method_name|
+      target.send(:add_method_tracer, method_name, "Custom/#{const_name}/#{method_name}")
     end
   end
 end
 
-# Serialization of the result page (hypermedia links + JSON generation).
-LinkedData::Serializer.singleton_class.class_eval do
-  include ::NewRelic::Agent::MethodTracer
-
-  add_method_tracer :build_response, 'Custom/LinkedData::Serializer/build_response'
-  add_method_tracer :serialize, 'Custom/LinkedData::Serializer/serialize'
-end
-
-# Solr query execution + response parsing (the HTTP call itself is already
-# instrumented as an External segment; this segment adds the parse cost).
-LinkedData::Models::Class.singleton_class.class_eval do
-  include ::NewRelic::Agent::MethodTracer
-
-  add_method_tracer :search, 'Custom/LinkedData::Models::Class/search'
+unless ENV['NEWRELIC_CUSTOM_TRACERS'] == 'off'
+  require 'new_relic/agent/method_tracer'
+  NewRelicMethodTracers.register
 end

--- a/config/newrelic_method_tracers.rb
+++ b/config/newrelic_method_tracers.rb
@@ -1,0 +1,49 @@
+# Custom New Relic method tracers for the /search request path.
+#
+# The GET /search transaction spends >90% of its time in application code
+# that the agent reports as a single opaque "Sinatra::Application#GET
+# (unknown)" segment (~830 ms of the ~890 ms average). These tracers split
+# that block into named Custom/* child segments so transaction traces and
+# the breakdown table show where the time actually goes.
+#
+# Must be loaded after init.rb so all traced methods are already defined.
+# When the agent is disabled (development/test), the tracers are no-ops.
+require 'new_relic/agent/method_tracer'
+
+module Sinatra
+  module Helpers
+    module SearchHelper
+      include ::NewRelic::Agent::MethodTracer
+
+      add_method_tracer :process_search, 'Custom/SearchHelper/process_search'
+      add_method_tracer :get_term_search_query, 'Custom/SearchHelper/get_term_search_query'
+      add_method_tracer :add_matched_fields, 'Custom/SearchHelper/add_matched_fields'
+      # Called once per returned document (default pagesize 50).
+      add_method_tracer :filter_attrs_by_language, 'Custom/SearchHelper/filter_attrs_by_language'
+    end
+
+    module ApplicationHelper
+      include ::NewRelic::Agent::MethodTracer
+
+      # Site-wide searches load every ontology here before querying Solr.
+      add_method_tracer :restricted_ontologies, 'Custom/ApplicationHelper/restricted_ontologies'
+      add_method_tracer :reply, 'Custom/ApplicationHelper/reply'
+    end
+  end
+end
+
+# Serialization of the result page (hypermedia links + JSON generation).
+LinkedData::Serializer.singleton_class.class_eval do
+  include ::NewRelic::Agent::MethodTracer
+
+  add_method_tracer :build_response, 'Custom/LinkedData::Serializer/build_response'
+  add_method_tracer :serialize, 'Custom/LinkedData::Serializer/serialize'
+end
+
+# Solr query execution + response parsing (the HTTP call itself is already
+# instrumented as an External segment; this segment adds the parse cost).
+LinkedData::Models::Class.singleton_class.class_eval do
+  include ::NewRelic::Agent::MethodTracer
+
+  add_method_tracer :search, 'Custom/LinkedData::Models::Class/search'
+end

--- a/helpers/search_helper.rb
+++ b/helpers/search_helper.rb
@@ -560,6 +560,12 @@ module Sinatra
         params.delete('query')
         text = params["q"]
 
+        # The agent strips query strings from request.uri, so record whether
+        # this search is ontology-scoped as a queryable transaction attribute
+        if defined?(::NewRelic::Agent)
+          ::NewRelic::Agent.add_custom_attributes(search_scoped: !params[ONTOLOGIES_PARAM].to_s.empty?)
+        end
+
         query = get_term_search_query(text, params)
         # puts "Edismax query: #{query}, params: #{params}"
         set_page_params(params)

--- a/test/helpers/test_newrelic_method_tracers.rb
+++ b/test/helpers/test_newrelic_method_tracers.rb
@@ -1,0 +1,53 @@
+require_relative '../test_case_helpers'
+
+# Guards the custom New Relic instrumentation of the /search request path
+# (config/newrelic_method_tracers.rb). If a traced method is renamed or
+# moved, add_method_tracer logs a warning and silently no-ops, so without
+# these assertions the instrumentation could vanish unnoticed while the
+# rest of the suite stays green.
+class TestNewRelicMethodTracers < TestCaseHelpers
+
+  TRACED_INSTANCE_METHODS = {
+    Sinatra::Helpers::SearchHelper => %i[process_search get_term_search_query
+                                         add_matched_fields filter_attrs_by_language],
+    Sinatra::Helpers::ApplicationHelper => %i[restricted_ontologies reply]
+  }.freeze
+
+  TRACED_CLASS_METHODS = {
+    LinkedData::Serializer => %i[build_response serialize],
+    LinkedData::Models::Class => %i[search]
+  }.freeze
+
+  def test_instance_method_tracers_registered
+    TRACED_INSTANCE_METHODS.each do |mod, methods|
+      methods.each do |method_name|
+        unbound = mod.instance_method(method_name)
+        refute_equal mod, unbound.owner,
+                     "#{mod}##{method_name} is not wrapped by a method tracer"
+        assert_wrapped_by_newrelic(unbound, "#{mod}##{method_name}")
+      end
+    end
+  end
+
+  def test_class_method_tracers_registered
+    TRACED_CLASS_METHODS.each do |cls, methods|
+      methods.each do |method_name|
+        unbound = cls.singleton_class.instance_method(method_name)
+        refute_equal cls.singleton_class, unbound.owner,
+                     "#{cls}.#{method_name} is not wrapped by a method tracer"
+        assert_wrapped_by_newrelic(unbound, "#{cls}.#{method_name}")
+      end
+    end
+  end
+
+  private
+
+  # The tracer wrapper is defined inside the newrelic_rpm gem, so the
+  # wrapped method's source_location must point there. This distinguishes
+  # a genuine tracer from any other module that happens to prepend.
+  def assert_wrapped_by_newrelic(unbound_method, label)
+    source_file = unbound_method.source_location&.first.to_s
+    assert_match(/newrelic/, source_file,
+                 "#{label} is wrapped, but not by newrelic_rpm (source: #{source_file})")
+  end
+end

--- a/test/helpers/test_newrelic_method_tracers.rb
+++ b/test/helpers/test_newrelic_method_tracers.rb
@@ -1,41 +1,32 @@
 require_relative '../test_case_helpers'
 
-# Guards the custom New Relic instrumentation of the /search request path
-# (config/newrelic_method_tracers.rb). If a traced method is renamed or
+# Guards the custom New Relic instrumentation registered by
+# config/newrelic_method_tracers.rb. If a traced method is renamed or
 # moved, add_method_tracer logs a warning and silently no-ops, so without
 # these assertions the instrumentation could vanish unnoticed while the
 # rest of the suite stays green.
+#
+# The tests iterate the registry itself, so entries added to
+# NewRelicMethodTracers::INSTANCE_METHODS / CLASS_METHODS are covered
+# automatically.
 class TestNewRelicMethodTracers < TestCaseHelpers
 
-  TRACED_INSTANCE_METHODS = {
-    Sinatra::Helpers::SearchHelper => %i[process_search get_term_search_query
-                                         add_matched_fields filter_attrs_by_language],
-    Sinatra::Helpers::ApplicationHelper => %i[restricted_ontologies reply]
-  }.freeze
-
-  TRACED_CLASS_METHODS = {
-    LinkedData::Serializer => %i[build_response serialize],
-    LinkedData::Models::Class => %i[search]
-  }.freeze
-
   def test_instance_method_tracers_registered
-    TRACED_INSTANCE_METHODS.each do |mod, methods|
+    NewRelicMethodTracers::INSTANCE_METHODS.each do |const_name, methods|
+      mod = Object.const_get(const_name)
       methods.each do |method_name|
-        unbound = mod.instance_method(method_name)
-        refute_equal mod, unbound.owner,
-                     "#{mod}##{method_name} is not wrapped by a method tracer"
-        assert_wrapped_by_newrelic(unbound, "#{mod}##{method_name}")
+        assert_wrapped_by_newrelic(mod.instance_method(method_name),
+                                   "#{const_name}##{method_name}")
       end
     end
   end
 
   def test_class_method_tracers_registered
-    TRACED_CLASS_METHODS.each do |cls, methods|
+    NewRelicMethodTracers::CLASS_METHODS.each do |const_name, methods|
+      singleton = Object.const_get(const_name).singleton_class
       methods.each do |method_name|
-        unbound = cls.singleton_class.instance_method(method_name)
-        refute_equal cls.singleton_class, unbound.owner,
-                     "#{cls}.#{method_name} is not wrapped by a method tracer"
-        assert_wrapped_by_newrelic(unbound, "#{cls}.#{method_name}")
+        assert_wrapped_by_newrelic(singleton.instance_method(method_name),
+                                   "#{const_name}.#{method_name}")
       end
     end
   end
@@ -44,10 +35,11 @@ class TestNewRelicMethodTracers < TestCaseHelpers
 
   # The tracer wrapper is defined inside the newrelic_rpm gem, so the
   # wrapped method's source_location must point there. This distinguishes
-  # a genuine tracer from any other module that happens to prepend.
+  # a genuine tracer from the untraced original (defined in this repo or
+  # its gems) and from any other module that happens to prepend.
   def assert_wrapped_by_newrelic(unbound_method, label)
     source_file = unbound_method.source_location&.first.to_s
     assert_match(/newrelic/, source_file,
-                 "#{label} is wrapped, but not by newrelic_rpm (source: #{source_file})")
+                 "#{label} is not wrapped by a newrelic_rpm method tracer (source: #{source_file})")
   end
 end


### PR DESCRIPTION
## Summary

`GET /search` is the highest externally consumed endpoint and averages ~890 ms. New Relic attributes **92.9% of that (~830 ms) to a single opaque controller segment**; all I/O combined is under 60 ms per request (Redis ~44 ms, Solr ~10 ms, AllegroGraph 0.02 calls/request). Production thread profiling cannot see inside the block either (workers are ~98% idle between requests, so a 5-minute sample catches almost no in-request frames).

This PR closes that observability gap with twelve permanent method tracers plus one custom transaction attribute, registered from a declarative registry so future endpoints are one-line additions. After deploy, transaction traces and the breakdown table show named `Custom/*` segments instead of one opaque block, naming the specific method responsible for the time.

## Evidence motivating this (last 24 h, 137,960 requests)

| Band | Count | Avg duration | All I/O combined |
|---|---|---|---|
| < 2 s | 136,186 (98.7%) | 870 ms | ~55 ms |
| 2 to 5 s | 1,761 (1.3%) | 2,377 ms | ~195 ms |
| > 5 s | 13 | 10,763 ms | ~11,400 ms (AllegroGraph query storms on cache miss) |

The dominant cost for 98.7% of traffic is in-process Ruby compute, not I/O. The rare > 5 s outliers are triple-store storms (separate, low-priority issue).

## What is instrumented

New file `config/newrelic_method_tracers.rb` (declarative registry, loaded from `app.rb` after `init`):

**GET /search pipeline**
- `SearchHelper#process_search`: whole pipeline; its self-time isolates the loop that builds read-only `LinkedData::Models::Class` objects from Solr documents
- `SearchHelper#get_term_search_query`: Solr query construction
- `SearchHelper#add_matched_fields`, `SearchHelper#filter_attrs_by_language`: highlight mapping and language filtering (the latter runs once per returned document, ~50/request; flagged in a comment as the one removal candidate if traces get noisy)
- `LinkedData::Models::Class.search`: Solr call including Ruby-side response parsing

**GET /ontologies/{ontology}/classes/{cls}/tree pipeline** (slowest transaction by average duration, 1.61 s; known future tuning target)
- `LinkedData::Models::Class#tree`, `#tree_sorted`, `#paths_to_root` (defined in an ontologies_linked_data concern, traced from here without touching that repo)

**App-wide (every endpoint benefits)**
- `ApplicationHelper#restricted_ontologies`: loads the full ontology access list (prime suspect for /search)
- `ApplicationHelper#reply`: access control, slice/user filtering, serialization entry
- `LinkedData::Serializer.build_response` / `.serialize`: hypermedia link and JSON generation

`SearchHelper#process_search` also records a `search_scoped` transaction attribute (the agent strips query strings from `request.uri`), enabling NRQL comparison of ontology-scoped vs site-wide searches:

```
SELECT average(duration) FROM Transaction WHERE name LIKE '%GET /search' FACET search_scoped
```

## Permanent, not temporary

These follow standard New Relic custom instrumentation practice. Per-call overhead is microseconds against an 870 ms transaction. With the agent disabled (development/test) they are no-ops. No logic, query, or response-format changes.

Kill switch: `NEWRELIC_CUSTOM_TRACERS=off` (plus restart) skips all registration, to rule instrumentation out while debugging.

## Test plan

- New: `test/helpers/test_newrelic_method_tracers.rb` iterates the registry and asserts every entry is wrapped by newrelic_rpm; fails if a traced method is renamed or registration silently no-ops. Registry-driven, so future entries are covered automatically.
- App boots in test env with all tracers active
- `test/controllers/test_search_controller.rb`: 13 tests, 147 assertions, 0 failures against the local backend stack
- `test/controllers/test_classes_controller.rb` (exercises /tree): 20 tests, 4,194 assertions, 0 failures
